### PR TITLE
Remove liveness probe from csi-node-driver-registrar container

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -92,14 +92,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          livenessProbe:
-            exec:
-              command:
-              - /csi-node-driver-registrar
-              - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
-              - --mode=kubelet-registration-probe
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
I noticed the following event being thrown while running a simple test:

```
resulting new interval: reason/Unhealthy (combined from similar events): Liveness probe errored: rpc error: code = Unknown desc = command error: time="2023-07-24T18:03:40Z" level=error msg="exec failed: unable to start container process: exec: \"/csi-node-driver-registrar\": stat /csi-node-driver-registrar: no such file or directory"
```

The `livenessProbe` clause was using `/csi-node-driver-registrar` but the container is built with the binary at `/usr/bin/csi-node-driver-registrar` [here](https://github.com/openshift/csi-node-driver-registrar/blob/f8635f761f8f59b76c1056034fc5addb29071cfe/Dockerfile.openshift.rhel7#L8).

In any case, the other CSI drivers in OCP do not define any `livenessProbe` clause for `csi-node-driver-registrar`, only for the `csi-driver` container. So this PR just removes the probe for `csi-node-driver-registrar` to be consistent with other drivers and to eliminate some event spam.

cc @openshift/storage
