### PR TITLE
OCPBUGS-17448: Delete static resources when ClusterCSIDriver is deleted

### DIFF
--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,72 @@
+package operator
+
+import (
+	"testing"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FakeOperator struct {
+	metav1.ObjectMeta
+	Spec   opv1.OperatorSpec
+	Status opv1.OperatorStatus
+}
+
+func TestGetOperatorSyncState(t *testing.T) {
+	deletionTimestamp := metav1.Now()
+
+	cases := []struct {
+		name          string
+		operator      *FakeOperator
+		expectedState opv1.ManagementState
+	}{
+		{
+			name: "should return managed when the operator state is managed",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Managed},
+			},
+
+			expectedState: opv1.Managed,
+		},
+		{
+			name: "should return unmanaged when the operator state is unmanaged",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Unmanaged},
+			},
+			expectedState: opv1.Unmanaged,
+		},
+		{
+			name: "should return removed when the operator state is removed",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: providerName},
+				Spec:       opv1.OperatorSpec{ManagementState: opv1.Removed},
+			},
+			expectedState: opv1.Removed,
+		},
+		{
+			name: "should return removed when the deletion timestamp is set",
+			operator: &FakeOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              providerName,
+					DeletionTimestamp: &deletionTimestamp,
+				},
+				Spec: opv1.OperatorSpec{ManagementState: opv1.Managed},
+			},
+			expectedState: opv1.Removed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			operatorClient := v1helpers.NewFakeOperatorClientWithObjectMeta(&tc.operator.ObjectMeta, &tc.operator.Spec, &tc.operator.Status, nil)
+			state := getOperatorSyncState(operatorClient)
+			if state != tc.expectedState {
+				t.Fatalf("expected sync state to be %v, got %v", tc.expectedState, state)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This cleans up static resources created by the operator when the ClusterCSIDriver object is deleted.

Deletion:

```
$ oc get clusterrole | grep secretproviderclasses- && oc get sa -n openshift-cluster-csi-drivers | grep secrets-store && oc get csidriver secrets-store.csi.k8s.io --no-headers
secretproviderclasses-admin-role                                            2023-08-04T23:31:37Z
secretproviderclasses-role                                                  2023-08-04T23:31:37Z
secretproviderclasses-viewer-role                                           2023-08-04T23:31:38Z
secrets-store-csi-driver-node-sa      1         16m
secrets-store-csi-driver-operator     1         22m
secrets-store.csi.k8s.io   false   true   false   <unset>   false   Ephemeral   16m
$ oc delete clustercsidriver secrets-store.csi.k8s.ioclustercsidriver.operator.openshift.io "secrets-store.csi.k8s.io" deleted
$ oc get clusterrole | grep secretproviderclasses- && oc get sa -n openshift-cluster-csi-drivers | grep secrets-store && oc get csidriver secrets-store.csi.k8s.io --no-headers
$ 
```

Creation:

```
$ oc apply -f - <<EOF
apiVersion: operator.openshift.io/v1
kind: ClusterCSIDriver
metadata:
    name: secrets-store.csi.k8s.io
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Trace
EOF
clustercsidriver.operator.openshift.io/secrets-store.csi.k8s.io created
$ oc get clusterrole | grep secretproviderclasses- && oc get sa -n openshift-cluster-csi-drivers | grep secrets-store && oc get csidriver secrets-store.csi.k8s.io --no-headers
secretproviderclasses-admin-role                                            2023-08-04T23:48:32Z
secretproviderclasses-role                                                  2023-08-04T23:48:32Z
secretproviderclasses-viewer-role                                           2023-08-04T23:48:32Z
secrets-store-csi-driver-node-sa      1         5s
secrets-store-csi-driver-operator     1         22m
secrets-store.csi.k8s.io   false   true   false   <unset>   false   Ephemeral   5s
$ 
```

/cc @openshift/storage
