### PR TITLE
Add must-gather image for secrets store

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,0 +1,5 @@
+FROM registry.ci.openshift.org/ocp/4.14:cli
+COPY must-gather/gather /usr/bin/
+RUN chmod +x /usr/bin/gather
+
+ENTRYPOINT /usr/bin/gather

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export LIVENESS_PROBE_IMAGE=quay.io/openshift/origin-csi-livenessprobe:latest
 
 # OLM
 
-To build an bundle and index images, use the `hack/create-bundle` script:
+To build bundle and index images, use the `hack/create-bundle` script:
 
 ```shell
 cd hack
@@ -42,3 +42,23 @@ cd hack
 ```
 
 At the end it will print a command that creates `Subscription` for the newly created index image.
+
+# Using the must-gather image
+
+The `must-gather` image for secrets-store-csi-driver-operator supplements the [openshift/must-gather](https://github.com/openshift/must-gather) image to gather Secrets Store related resources.
+
+```shell
+oc adm must-gather --image=quay.io/openshift/origin-secrets-store-csi-mustgather:latest
+```
+
+This command creates a must-gather containing:
+- Logs and resources in the operator namespace (`openshift-cluster-csi-drivers`)
+- `SecretProviderClass` and `SecretProviderClassPodStatus` objects
+- `ClusterCSIDriver` and `CSIDriver` objects
+
+To build the `must-gather` image locally:
+
+```shell
+REPO=quay.io/<user>/secrets-store-csi-mustgather:latest
+docker build -t ${REPO} -f Dockerfile.mustgather .
+```

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SUBSCRIPTION_NAME=${SUBSCRIPTION_NAME:-secrets-store-csi-driver-operator}
+DESTINATION_DIR=${DESTINATION_DIR:-must-gather/}
+
+NAMESPACE=$(/usr/bin/oc get subscription --all-namespaces --field-selector="metadata.name=${SUBSCRIPTION_NAME}" --output='jsonpath={.items[0].metadata.namespace}')
+if [ $? -ne 0 ]; then
+	echo "Failed to find namespace for subscription ${SUBSCRIPTION_NAME}"
+	exit 1
+fi
+echo "Found subscription ${SUBSCRIPTION_NAME} in namespace ${NAMESPACE}"
+
+/usr/bin/oc adm inspect namespace/${NAMESPACE} --dest-dir=must-gather/
+
+for CRD in $(/usr/bin/oc get crd | grep secrets-store.csi.x-k8s.io | awk '{print $1}'); do
+    echo "Gathering data for CRD ${CRD}"
+    /usr/bin/oc adm inspect ${CRD} --all-namespaces --dest-dir=must-gather/
+done
+
+echo "Gathering data for ClusterCSIDrivers and CSIDrivers"
+/usr/bin/oc adm inspect clustercsidrivers,csidrivers --dest-dir=must-gather/
+
+exit 0


### PR DESCRIPTION
This adds a must-gather image to fetch relevant secrets store resources.

Tested with:
```
oc adm must-gather --image=quay.io/jdobson/secrets-store-csi-mustgather
```

/cc @openshift/storage @jsafrane @ropatil010
