### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,6 @@ approvers:
 - gnufied
 - jsafrane
 - RomanBednar
-- tsmetana
 - mpatlasov
+- tsmetana
 component: "Storage / Operators"


### PR DESCRIPTION
This PR does nothing, except for _hopefully_ bring the `secrets-store-csi-mustgather` image tag into existence:
```
$ docker pull registry.ci.openshift.org/origin/4.14:secrets-store-csi-mustgather
Error response from daemon: manifest for registry.ci.openshift.org/origin/4.14:secrets-store-csi-mustgather not found: manifest unknown: manifest unknown
```
[ci docs](https://docs.ci.openshift.org/docs/architecture/ci-operator/#publishing-container-images) state: `Images published in this manner are produced when the source repository branch is updated (e.g. when a PR merges or the branch is manually updated), not when the images are built as in an in-flight PR.`