### PR TITLE
OCPBUGS-17795: secrets-store-csi-driver-operator should not contain stable channel

### DIFF
--- a/config/manifests/secrets-store-csi-driver-operator.package.yaml
+++ b/config/manifests/secrets-store-csi-driver-operator.package.yaml
@@ -2,3 +2,4 @@ packageName: secrets-store-csi-driver-operator
 channels:
 - name: preview
   currentCSV: secrets-store-csi-driver-operator.v4.14.0
+defaultChannel: preview


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17795
/cc @openshift/storage
