### PR TITLE
OCPBUGS-24312: failed to list *v1.APIServer: apiservers.config.openshift.io

### DIFF
--- a/config/manifests/preview/secrets-store-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/preview/secrets-store-csi-driver-operator.clusterserviceversion.yaml
@@ -236,6 +236,7 @@ spec:
             resources:
             - infrastructures
             - proxies
+            - apiservers
             verbs:
             - get
             - list


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-24312
/cc @openshift/storage
