### PR TITLE
STOR-1590: Bump OLM metadata to 4.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,secrets-store-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.15:secrets-store-csi-driver-operator,./Dockerfile.openshift,.)
+$(call build-image,secrets-store-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.16:secrets-store-csi-driver-operator,./Dockerfile.openshift,.)
 
 clean:
 	$(RM) secrets-store-csi-driver-operator

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build bundle and index images, use the `hack/create-bundle` script:
 
 ```shell
 cd hack
-./create-bundle registry.ci.openshift.org/ocp/4.15:secrets-store-csi-driver registry.ci.openshift.org/ocp/4.15:secrets-store-csi-driver-operator quay.io/<my_user>/secrets-store-bundle quay.io/<my_user>/secrets-store-index
+./create-bundle registry.ci.openshift.org/ocp/4.16:secrets-store-csi-driver registry.ci.openshift.org/ocp/4.16:secrets-store-csi-driver-operator quay.io/<my_user>/secrets-store-bundle quay.io/<my_user>/secrets-store-index
 ```
 
 At the end it will print a command that creates `Subscription` for the newly created index image.

--- a/config/manifests/preview/secrets-store-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/preview/secrets-store-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: secrets-store-csi-driver-operator.v4.15.0
+  name: secrets-store-csi-driver-operator.v4.16.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/secrets-store-csi-driver-operator
     createdAt: "2023-06-12T00:00:00Z"
     description: Install and configure Secrets Store CSI driver.
-    olm.skipRange: ">=4.13.0-0 <4.15.0"
+    olm.skipRange: ">=4.13.0-0 <4.16.0"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
@@ -34,7 +34,7 @@ spec:
       url: https://github.com/openshift/secrets-store-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/secrets-store-csi-driver-operator
-  version: 4.15.0
+  version: 4.16.0
   maturity: preview
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -44,7 +44,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: secrets-store-csi-driver-operator
-    alm-status-descriptors: secrets-store-csi-driver-operator.v4.15.0
+    alm-status-descriptors: secrets-store-csi-driver-operator.v4.16.0
   selector:
     matchLabels:
       alm-owner-metering: secrets-store-csi-driver-operator

--- a/config/manifests/secrets-store-csi-driver-operator.package.yaml
+++ b/config/manifests/secrets-store-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: secrets-store-csi-driver-operator
 channels:
 - name: preview
-  currentCSV: secrets-store-csi-driver-operator.v4.15.0
+  currentCSV: secrets-store-csi-driver-operator.v4.16.0


### PR DESCRIPTION
Increase OCP version in OLM metadata.

@openshift/storage

