### PR TITLE
NO-JIRA: Move secrets-store-csi-driver-operator to rhel9

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.16:cli
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 RUN dnf install -y --nodocs --setopt=install_weak_deps=False openshift-clients \
   && dnf clean all && rm -rf /var/cache/*
 COPY must-gather/gather /usr/bin/

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver-operator
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver-operator/secrets-store-csi-driver-operator /usr/bin/
 ENTRYPOINT ["/usr/bin/secrets-store-csi-driver-operator"]
 LABEL io.k8s.display-name="OpenShift Secrets Store CSI Driver Operator" \

--- a/config/manifests/preview/image-references
+++ b/config/manifests/preview/image-references
@@ -7,7 +7,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-secrets-store-csi-driver-operator:latest
-  - name: secrets-store-csi-driver-container-rhel8
+  - name: secrets-store-csi-driver-container
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-secrets-store-csi-driver:latest


### PR DESCRIPTION
Needed for https://github.com/openshift-eng/ocp-build-data/pull/4396
/cc @openshift/storage