### PR TITLE
STOR-1828: Limit must-gather log collection by timestamps

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/4.16:cli
 RUN dnf install -y --nodocs --setopt=install_weak_deps=False openshift-clients \
   && dnf clean all && rm -rf /var/cache/*
-COPY must-gather/gather /usr/bin/
+COPY must-gather/gather must-gather/gather-common.sh /usr/bin/
 RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+source $(dirname "$0")/gather-common.sh
+get_log_collection_args
+
 SUBSCRIPTION_NAME=${SUBSCRIPTION_NAME:-secrets-store-csi-driver-operator}
 DESTINATION_DIR=${DESTINATION_DIR:-must-gather/}
 
@@ -10,14 +13,14 @@ if [ $? -ne 0 ]; then
 fi
 echo "Found subscription ${SUBSCRIPTION_NAME} in namespace ${NAMESPACE}"
 
-/usr/bin/oc adm inspect namespace/${NAMESPACE} --dest-dir=must-gather/
+/usr/bin/oc adm inspect ${log_collection_args} namespace/${NAMESPACE} --dest-dir=must-gather/
 
 for CRD in $(/usr/bin/oc get crd | grep secrets-store.csi.x-k8s.io | awk '{print $1}'); do
     echo "Gathering data for CRD ${CRD}"
-    /usr/bin/oc adm inspect ${CRD} --all-namespaces --dest-dir=must-gather/
+    /usr/bin/oc adm inspect ${log_collection_args} ${CRD} --all-namespaces --dest-dir=must-gather/
 done
 
 echo "Gathering data for ClusterCSIDrivers and CSIDrivers"
-/usr/bin/oc adm inspect clustercsidrivers,csidrivers --dest-dir=must-gather/
+/usr/bin/oc adm inspect ${log_collection_args} clustercsidrivers,csidrivers --dest-dir=must-gather/
 
 exit 0

--- a/must-gather/gather-common.sh
+++ b/must-gather/gather-common.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This is copied from https://github.com/openshift/must-gather/blob/a175e0178104f4f794828c02245cd2de896cef0e/collection-scripts/common.sh
+
+get_log_collection_args() {
+	# validation of MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME is done by the
+	# caller (oc adm must-gather) so it's safe to use the values as they are.
+	log_collection_args=""
+
+	if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+		log_collection_args=--since="${MUST_GATHER_SINCE}"
+	fi
+	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+		log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
+	fi
+
+	# oc adm node-logs `--since` parameter is not the same as oc adm inspect `--since`.
+	# it takes a simplified duration in the form of '(+|-)[0-9]+(s|m|h|d)' or
+	# an ISO formatted time. since MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME
+	# are formatted differently, we re-format them so they can be used
+	# transparently by node-logs invocations.
+	node_log_collection_args=""
+
+	if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+		since=$(echo "${MUST_GATHER_SINCE:-}" | sed 's/\([0-9]*[dhms]\).*/\1/')
+		node_log_collection_args=--since="-${since}"
+	fi
+	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+		iso_time=$(echo "${MUST_GATHER_SINCE_TIME}" | sed 's/T/ /; s/Z//')
+		node_log_collection_args=--since="${iso_time}"
+	fi
+}


### PR DESCRIPTION
Use MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME env. vars to limit log collection. They are set by `oc adm must-gather --since` or `--since-time`.

Tested by:
```
oc adm must-gather --image=quay.io/jsafrane/scratch:ssmg1 --since=5m
```

This PR contains a partial copy of https://github.com/openshift/must-gather/blob/a175e0178104f4f794828c02245cd2de896cef0e/collection-scripts/common.sh, I haven't found a way how to share the script nicely.

