### PR TITLE
OCPBUGS-34323: Collection-scripts as go package

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,7 +1,9 @@
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 RUN dnf install -y --nodocs --setopt=install_weak_deps=False openshift-clients \
   && dnf clean all && rm -rf /var/cache/*
-COPY must-gather/gather must-gather/gather-common.sh /usr/bin/
+
+COPY must-gather/gather /usr/bin/
+COPY vendor/github.com/openshift/must-gather/collection-scripts/common.sh /usr/bin/gather-common.sh
 RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/openshift/api v0.0.0-20240202140003-8b34b9854c7f
 	github.com/openshift/build-machinery-go v0.0.0-20231128094528-1e9b1b0595c8
 	github.com/openshift/client-go v0.0.0-20240125160436-aa5df63097c4
+	github.com/openshift/must-gather v0.0.0-20240606205211-408ab8661885
 	github.com/openshift/library-go v0.0.0-20240130085015-2ad786549f07
 	github.com/prometheus/client_golang v1.18.0
 	github.com/spf13/cobra v1.8.0
@@ -113,3 +114,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/openshift/must-gather => ../must-gather

--- a/pkg/dependencymagnet/dependencymagnet.go
+++ b/pkg/dependencymagnet/dependencymagnet.go
@@ -5,4 +5,5 @@ package dependencymagnet
 
 import (
 	_ "github.com/openshift/build-machinery-go"
+	_ "github.com/openshift/must-gather/collection-scripts"
 )

--- a/vendor/github.com/openshift/must-gather/LICENSE
+++ b/vendor/github.com/openshift/must-gather/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/must-gather/collection-scripts/OWNERS
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - sferich888
+  - davemulford
+  - chrisdolphy
+  - RickJWagner
+approvers:
+  - sferich888
+  - davemulford
+  - chrisdolphy
+  - RickJWagner

--- a/vendor/github.com/openshift/must-gather/collection-scripts/common.sh
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/common.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function get_operator_ns() {
+    local operator_name=$(echo \"$1\")
+    cmd="$(echo "oc get subs -A -o template --template '{{range .items}}{{if eq .spec.name ""${operator_name}""}}{{.metadata.namespace}}{{\"\\n\"}}{{end}}{{end}}'")"
+    operator_ns="$(eval "$cmd")"
+
+    if [ -z "${operator_ns}" ]; then
+        echo "INFO: ${operator_name} not detected. Skipping."
+        exit 0
+    fi
+
+    if [[ "$(echo "${operator_ns}" | wc -l)" -gt 1 ]]; then
+        echo "ERROR: found more than one ${operator_name} subscription. Exiting."
+        exit 1
+    fi
+}
+
+get_log_collection_args() {
+	# validation of MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME is done by the
+	# caller (oc adm must-gather) so it's safe to use the values as they are.
+	log_collection_args=""
+
+	if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+		log_collection_args=--since="${MUST_GATHER_SINCE}"
+	fi
+	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+		log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
+	fi
+
+	# oc adm node-logs `--since` parameter is not the same as oc adm inspect `--since`.
+	# it takes a simplified duration in the form of '(+|-)[0-9]+(s|m|h|d)' or
+	# an ISO formatted time. since MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME
+	# are formatted differently, we re-format them so they can be used
+	# transparently by node-logs invocations.
+	node_log_collection_args=""
+
+	if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+		since=$(echo "${MUST_GATHER_SINCE:-}" | sed 's/\([0-9]*[dhms]\).*/\1/')
+		node_log_collection_args=--since="-${since}"
+	fi
+	if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+		iso_time=$(echo "${MUST_GATHER_SINCE_TIME}" | sed 's/T/ /; s/Z//')
+		node_log_collection_args=--since="${iso_time}"
+	fi
+}

--- a/vendor/github.com/openshift/must-gather/collection-scripts/doc.go
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/doc.go
@@ -1,0 +1,3 @@
+// required for gomod to pull in packages.
+
+package alpha_must_gather

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# generate /must-gather/version file
+. version
+echo "openshift/must-gather"> /must-gather/version
+version >> /must-gather/version
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+# Store PIDs of all the subprocesses
+pids=()
+
+# Named resource list, eg. ns/openshift-config
+named_resources=()
+
+# Resource groups list, eg. pods
+group_resources=()
+
+# Resources to gather with `--all-namespaces` option
+all_ns_resources=()
+
+# Cluster Version Information
+named_resources+=(ns/openshift-cluster-version)
+group_resources+=(clusterversion)
+
+# Operator and APIService Resources
+group_resources+=(clusteroperators apiservices)
+
+# Certificate Resources
+group_resources+=(certificatesigningrequests)
+
+# Machine/Node Resources
+group_resources+=(nodes)
+
+# Namespaces/Project Resources
+named_resources+=(ns/default ns/openshift ns/kube-system ns/openshift-etcd)
+
+# Storage Resources
+group_resources+=(storageclasses persistentvolumes volumeattachments csidrivers csinodes volumesnapshotclasses volumesnapshotcontents)
+all_ns_resources+=(csistoragecapacities)
+
+# Image-source Resources
+group_resources+=(imagecontentsourcepolicies.operator.openshift.io)
+
+# Networking Resources
+group_resources+=(networks.operator.openshift.io)
+
+# NodeNetworkState
+resources+=(nodenetworkstates nodenetworkconfigurationenactments nodenetworkconfigurationpolicies)
+
+# Assisted Installer
+all_ns_resources+=(ns/assisted-installer)
+
+# Leases
+all_ns_resources+=(leases)
+
+# Run the Collection of Resources using inspect
+# running across all-namespaces for the few "Autoscaler" resources.
+oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${named_resources[@]}" &
+pids+=($!)
+
+filtered_group_resources=()
+for gr in "${group_resources[@]}"
+do
+  oc get "$gr" > /dev/null 2>&1
+  if [[ "$?" -eq 0 ]]; then
+    filtered_group_resources+=("$gr")
+  fi
+done
+group_resources_text=$(IFS=, ; echo "${filtered_group_resources[*]}")
+oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${group_resources_text}" &
+pids+=($!)
+
+oc adm inspect ${log_collection_args} --dest-dir must-gather --rotated-pod-logs "${all_ns_resources[@]}" --all-namespaces &
+pids+=($!)
+
+# Gather Insights Operator Archives
+/usr/bin/gather_insights &
+pids+=($!)
+
+# Gather monitoring data from the cluster
+/usr/bin/gather_monitoring &
+pids+=($!)
+
+# Gather optional operator resources from all namespaces
+/usr/bin/gather_olm &
+pids+=($!)
+
+# Gather API Priority and Fairness Endpoints
+/usr/bin/gather_priority_and_fairness &
+pids+=($!)
+
+# Gather etcd information
+/usr/bin/gather_etcd &
+pids+=($!)
+
+# Gather Service Logs (using a supplemental Script); Scoped to Masters.
+/usr/bin/gather_service_logs master &
+pids+=($!)
+
+# Gather Windows Kubernetes component logs
+/usr/bin/gather_windows_node_logs &
+pids+=($!)
+
+# Gather HAProxy config files
+/usr/bin/gather_haproxy_config &
+pids+=($!)
+
+# Gather kas startup and termination logs
+/usr/bin/gather_kas_startup_termination_logs &
+pids+=($!)
+
+# Gather network logs
+/usr/bin/gather_network_logs_basics &
+pids+=($!)
+
+# Gather metallb logs
+/usr/bin/gather_metallb &
+pids+=($!)
+
+# Gather NMState
+/usr/bin/gather_nmstate &
+pids+=($!)
+
+# Gather SR-IOV resources
+/usr/bin/gather_sriov &
+pids+=($!)
+
+# Gather PodNetworkConnectivityCheck
+/usr/bin/gather_podnetworkconnectivitycheck &
+pids+=($!)
+
+# Gather On-Disk MachineConfig files
+/usr/bin/gather_machineconfig_ondisk &
+pids+=($!)
+
+# Gather vSphere resources. This is NOOP on non-vSphere platform.
+/usr/bin/gather_vsphere &
+pids+=($!)
+
+# Gather Performance profile information
+/usr/bin/gather_ppc &
+pids+=($!)
+
+# Check if PID array has any values, if so, wait for them to finish
+if [ ${#pids[@]} -ne 0 ]; then
+    echo "Waiting on subprocesses to finish execution."
+    wait "${pids[@]}"
+fi
+
+# Gather ARO information
+/usr/bin/gather_aro
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_apirequestcounts
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_apirequestcounts
@@ -1,0 +1,21 @@
+#!/bin/bash
+BASE_COLLECTION_PATH=${BASE_COLLECTION_PATH:-"/must-gather"}
+TARGET_PATH="${BASE_COLLECTION_PATH}/requests/"
+
+mkdir -p ${TARGET_PATH}
+
+echo "Getting apirequestcounts"
+oc get apirequestcounts -o json > ${TARGET_PATH}/apirequestscounts.json
+
+echo "Calculating top20 resources"
+jq -r '.items | map({"name":.metadata.name, "requestCount": .status.requestCount}) | sort_by(-.requestCount)[:20][] | "\(.requestCount): \(.name)"' ${TARGET_PATH}/apirequestscounts.json > ${TARGET_PATH}/top20-resources-last24h
+
+echo "Calculating top20 users"
+jq -r '.items | map(
+  .metadata.name as $resource |
+  .status.last24h | map(.byNode // [] | map(.byUser // [])) | flatten | flatten |
+  group_by(.username) | map(
+    reduce .[] as $username ({"requestCount":0}; {"username":$username.username, "requestCount":(.requestCount + $username.requestCount)})
+  ) | map(. + {"resource":$resource})) | flatten |
+  sort_by(-.requestCount)[:20][] |
+  "\(.requestCount): \(.username) \(.resource)"' ${TARGET_PATH}/apirequestscounts.json > ${TARGET_PATH}/top20-users-last24h

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_aro
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_aro
@@ -1,0 +1,22 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+ARO_CR_NAME="clusters.aro.openshift.io"
+
+IS_ARO=$(oc get ${ARO_CR_NAME} --ignore-not-found=true )
+if [ -z "$IS_ARO" ]; then
+    exit 0
+fi
+
+function gather_aro() {
+    echo "INFO: Collecting ARO Cluster Data"
+    declare -a INSPECT_TARGETS=(${ARO_CR_NAME} "ns/openshift-azure-operator" "ns/openshift-azure-logging")
+
+    for TARGET in "${INSPECT_TARGETS[@]}"; do
+        oc adm inspect --dest-dir "${BASE_COLLECTION_PATH}" "${TARGET}"
+    done
+}
+
+gather_aro
+
+# force disk flush to ensure that all data gathered are written
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_audit_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_audit_logs
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Downloads the audit.log (and its rotated copies) from
+# /var/logs/{kube-apiserver,openshift-apiserver} on each
+# master node.
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+
+profile=$(oc get apiservers.v1.config.openshift.io -o jsonpath='{.items[0].spec.audit.profile}')
+if [ -z "${profile}" ] || [ "${profile}" == None ]; then
+  if [ "${1}" == "--force" ]; then
+    cat << EOF
+WARNING: To raise a Red Hat support request, it is required to set the top level audit policy to
+         Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
+         be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
+         Default" and reproduce the issue while gathering audit logs.
+EOF
+  else
+    cat << EOF
+ERROR: To raise a Red Hat support request, it is required to set the top level audit policy to
+       Default, WriteRequestBodies, or AllRequestBodies to generate audit log events that can
+       be analyzed by support. Try 'oc edit apiservers' and set 'spec.audit.profile' back to
+       "Default" and reproduce the issue while gathering audit logs. You can use "--force" to
+       override this error.
+EOF
+    exit 1
+  fi
+fi
+
+echo "WARNING: Collecting one or more audit logs on ALL masters in your cluster. This could take a large amount of time." >&2
+
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+# $5 - --since=ISO time, if provided via MUST_GATHER_SINCE_TIME
+paths=(openshift-apiserver kube-apiserver oauth-apiserver etcd oauth-server)
+for path in "${paths[@]}" ; do
+  output_dir="${BASE_COLLECTION_PATH}/audit_logs/$path"
+  mkdir -p "$output_dir"
+  oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} --role=master --path="$path" | \
+  tee "${BASE_COLLECTION_PATH}/audit_logs/$path.audit_logs_listing" | \
+  grep -v ".terminating" | \
+  grep -v ".lock" | \
+  sed "s|^|$path $output_dir |" | \
+  sed "s|$| '${node_log_collection_args}'|"
+done | \
+xargs --max-args=5 --max-procs=45 bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs ${5:+"$5"} $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+
+# gathers audit logs from prometheus-adapter pod running in openshift-monitoring namespace.
+gather_monitoring_audit_logs() {
+  local prometheus_adapter_pods
+  prometheus_adapter_pods="$(oc get pods \
+    -n openshift-monitoring \
+    -l app.kubernetes.io/name=prometheus-adapter \
+    -o jsonpath='{.items[*].metadata.name}' )"
+
+  num_prom_adapter_pods=$(echo "$prometheus_adapter_pods" | wc -w)
+  # Only either of prometheus-adapter or metrics-server will be running
+  # in a cluster at a time. Currently metrics-server is tech preview but
+  # planning to go GA in 4.16
+  #
+  # TODO(slashpai): Remove prometheus-adapter code once it's completely removed in CMO
+  if [ "$num_prom_adapter_pods" -gt 0 ]; then
+    # NOTE: there should only be one pod for prometheus-adapter but treating it
+    # as array ensures multiple pods are covered as well.
+    for pod in $prometheus_adapter_pods; do
+      local output_dir="${BASE_COLLECTION_PATH}/audit_logs/monitoring/$pod"
+      mkdir -p "$output_dir"
+
+      echo "Collecting logs from prometheus adapter pod: $pod"
+      oc cp -n openshift-monitoring "$pod:var/log/adapter" "$output_dir"
+    done
+  else
+    local metrics_server_pods
+    metrics_server_pods="$(oc get pods \
+      -n openshift-monitoring \
+      -l app.kubernetes.io/name=metrics-server \
+      -o jsonpath='{.items[*].metadata.name}' )"
+
+    for pod in $metrics_server_pods; do
+      local output_dir="${BASE_COLLECTION_PATH}/audit_logs/monitoring/$pod"
+      mkdir -p "$output_dir"
+
+      echo "Collecting logs from metrics server pod: $pod"
+      oc cp -n openshift-monitoring "$pod:var/log/metrics-server" "$output_dir"
+    done
+  fi
+}
+
+gather_monitoring_audit_logs
+
+echo "INFO: Audit logs collected."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_core_dumps
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_core_dumps
@@ -1,0 +1,54 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="must-gather"
+CORE_DUMP_PATH=${OUT:-"${BASE_COLLECTION_PATH}/node_core_dumps"}
+
+mkdir -p "${CORE_DUMP_PATH}"/
+
+function get_dump_off_node {
+    local debugPod=""
+    
+    #Get debug pod's name
+    debugPod=$(oc debug --to-namespace="default" node/"$1" -o jsonpath='{.metadata.name}')
+
+    #Start Debug pod force it to stay up until removed in "default" namespace
+    oc debug --to-namespace="default" node/"$1" -- /bin/bash -c 'sleep 300' > /dev/null 2>&1 &
+
+    #Mimic a normal oc call, i.e pause between two successive calls to allow pod to register
+    sleep 2
+    oc wait -n "default" --for=condition=Ready pod/"$debugPod" --timeout=30s
+
+    if [ -z "$debugPod" ]
+    then
+      echo "Debug pod for node ""$1"" never activated"
+    else
+      #Copy Core Dumps out of Nodes suppress Stdout
+      echo "Copying core dumps on node ""$1"""
+      oc cp  --loglevel 1 -n "default" "$debugPod":/host/var/lib/systemd/coredump "${CORE_DUMP_PATH}"/"$1"_core_dump > /dev/null 2>&1 && PIDS+=($!)
+
+      #clean up debug pod after we are done using them  
+      oc delete pod "$debugPod" -n "default"  
+    fi
+}
+
+function gather_core_dump_data {
+  #Run coredump pull function on all nodes in parallel
+  for NODE in ${NODES}; do
+    get_dump_off_node "${NODE}" &
+  done
+}
+
+if [ $# -eq 0 ]; then
+    echo "WARNING: Collecting core dumps on ALL linux nodes in your cluster. This could take a long time."
+fi
+
+PIDS=()
+NODES="${*:-$(oc get nodes -o jsonpath='{.items[?(@.status.nodeInfo.operatingSystem=="linux")].metadata.name}')}"
+
+gather_core_dump_data
+
+echo "INFO: Waiting for node core dump collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: Node core dump collection to complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_etcd
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_etcd
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#Safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+BASE_COLLECTION_PATH="/must-gather"
+ETCD_LOG_PATH="${BASE_COLLECTION_PATH}/etcd_info"
+
+ETCDCTL_CONTAINER='etcdctl'
+
+RUNNING_ETCD_POD=$(oc get pod -n openshift-etcd --no-headers -l app=etcd|grep Running| grep -o -m 1 '\S*etcd\S*')
+
+# We cannot rely on ETCDCTL_ENDPOINTS on container because it may contain bootstrap VM
+ETCDCTL_ENDPOINTS=$(oc exec "${RUNNING_ETCD_POD}"  -n openshift-etcd -c ${ETCDCTL_CONTAINER} -- /bin/sh -c "etcdctl member list" | awk -F', ' '{printf "%s%s",sep,$5; sep=","}')
+
+function ocp4etcdctl {
+    oc -n openshift-etcd exec -c "${ETCDCTL_CONTAINER}" "${RUNNING_ETCD_POD}" -- env "ETCDCTL_ENDPOINTS=${ETCDCTL_ENDPOINTS}" etcdctl "$@"
+}
+
+if [[ -z $RUNNING_ETCD_POD ]];then
+    echo "ERROR: No running etcd pods found" >&2
+    exit 1
+fi
+
+echo "Getting information from pod \"${RUNNING_ETCD_POD}\", container \"${ETCDCTL_CONTAINER}\""
+echo "Using endpoints: ${ETCDCTL_ENDPOINTS}"
+
+mkdir -p ${ETCD_LOG_PATH}
+
+echo "INFO: Starting getting etcd information"
+
+# If one ocp4etcdctl execution fails, the other ones should be tried anyway.
+set +o errexit
+
+PIDS=()
+
+# member list
+echo "INFO: Getting etcdctl member list"
+ocp4etcdctl member list -w json > ${ETCD_LOG_PATH}/member_list.json &
+PIDS+=($!)
+
+# endpoint status
+echo "INFO: Getting etcdctl endpoint status"
+ocp4etcdctl endpoint status -w json > ${ETCD_LOG_PATH}/endpoint_status.json &
+PIDS+=($!)
+
+# endpoint health
+echo "INFO: Getting etcdctl endpoint health"
+ocp4etcdctl endpoint health -w json > ${ETCD_LOG_PATH}/endpoint_health.json &
+PIDS+=($!)
+
+# alarm list
+echo "INFO: Getting etcdctl alarm list"
+ocp4etcdctl alarm list -w json > ${ETCD_LOG_PATH}/alarm_list.json &
+PIDS+=($!)
+
+echo "INFO: Waiting for etcd info collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: Done collecting etcd information"
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_haproxy_config
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_haproxy_config
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="must-gather"
+HAPROXY_CONFIG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/ingress_controllers"}
+
+mkdir -p "${HAPROXY_CONFIG_PATH}"/
+
+function gather_haproxy_config {
+    echo "INFO: Gathering HAProxy config files"
+    INGRESS_CONTROLLERS=$(oc get ingresscontroller -n openshift-ingress-operator --no-headers -o custom-columns=":metadata.name")
+    for IC in ${INGRESS_CONTROLLERS}; do
+        PODS=$(oc get pods -n openshift-ingress --no-headers -o custom-columns=":metadata.name" --selector ingresscontroller.operator.openshift.io/deployment-ingresscontroller="${IC}")
+        for POD in ${PODS}; do
+            timeout -v 3m oc cp openshift-ingress/"${POD}":/var/lib/haproxy/conf/haproxy.config "${HAPROXY_CONFIG_PATH}"/"${IC}"/"${POD}"/haproxy.config &
+            PIDS+=($!)
+        done
+    done
+}
+
+PIDS=()
+gather_haproxy_config
+
+echo "INFO: Waiting for HAProxy config collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: HAProxy config collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_ingress_node_firewall
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_ingress_node_firewall
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+BASE_COLLECTION_PATH="must-gather"
+get_operator_ns "ingress-node-firewall"
+get_log_collection_args
+
+function get_ingress_node_firewall_namespaced_crs() {
+    declare -a INGRESS_NODE_FIREWALL_NAMESPACED_CRDS=("ingressnodefirewallconfigs" "ingressnodefirewallnodestates")
+    
+    for CRD in "${INGRESS_NODE_FIREWALL_NAMESPACED_CRDS[@]}"; do
+        oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${operator_ns} "${CRD}"
+    done
+}
+
+function get_ingress_node_firewall_cluster_crs() {
+    declare -a INGRESS_NODE_FIREWALL_CLUSTER_CRDS=("ingressnodefirewalls")
+
+    for CRD in "${INGRESS_NODE_FIREWALL_CLUSTER_CRDS[@]}"; do
+        oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
+    done
+}
+
+
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
+get_ingress_node_firewall_namespaced_crs
+get_ingress_node_firewall_cluster_crs
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_insights
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_insights
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Gather the insights archive data from insights operator
+
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+INSIGHTS_DATA_PATH="${BASE_COLLECTION_PATH}/insights-data"
+
+mkdir -p "${INSIGHTS_DATA_PATH}"/
+COLLECTOR=${1:-rsync}         #Define what oc collector to use (oc rsync or oc cp)
+
+INSIGHTS_OPERATOR_POD=$(oc get pods --namespace=openshift-insights -o custom-columns=:metadata.name --no-headers  --field-selector=status.phase=Running)
+
+echo "INFO: Collecting Insights Archives from $INSIGHTS_OPERATOR_POD"
+oc $COLLECTOR --namespace=openshift-insights openshift-insights/$INSIGHTS_OPERATOR_POD:/var/lib/insights-operator $INSIGHTS_DATA_PATH
+
+#TODO: Prune or Limit the data that is collected/synced (as this might be a lot to add to the archive).
+
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_kas_startup_termination_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_kas_startup_termination_logs
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Downloads the startup.log and termination.log (and its rotated copies) from /var/logs/kube-apiserver on each master node
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+
+echo "WARNING: Collecting one or more kube-apiserver related logs on ALL masters in your cluster. This could take a large amount of time." >&2
+
+# the command executed by xargs below expects four parameters:
+# $1 - node path under /var/logs to download
+# $2 - local output path
+# $3 - node name
+# $4 - log file name
+# $5 - --since=ISO time, if provided via MUST_GATHER_SINCE_TIME
+paths=(kube-apiserver)
+for path in "${paths[@]}" ; do
+  output_dir="${BASE_COLLECTION_PATH}/static-pods/$path"
+  mkdir -p "$output_dir"
+  oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} --role=master --path="$path" | \
+  grep -E '(startup.*.log|termination.log)' | \
+  sed "s|^|$path $output_dir |" | \
+  sed "s|$| '${node_log_collection_args}'|"
+done | \
+xargs --max-args=5 --max-procs=45 --no-run-if-empty bash -c \
+  'echo "INFO: Started  downloading $1/$4 from $3";
+  oc adm node-logs ${5:+"$5"} ${node_log_collection_args} $3 --path=$1/$4 | gzip > $2/$3-$4.gz;
+  echo "INFO: Finished downloading $1/$4 from $3"' \
+  bash
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_machineconfig_ondisk
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_machineconfig_ondisk
@@ -1,0 +1,32 @@
+#!/bin/bash 
+
+BASE_COLLECTION_PATH="must-gather"
+MACHINECONFIG_CONFIG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/machine_config_ondisk"}
+
+mkdir -p "${MACHINECONFIG_CONFIG_PATH}"/
+
+# gather_machineconfig_ondisk_currentconfig collects the MCO's "on-disk" MachineConfig files
+function gather_machineconfig_ondisk {
+     
+    echo "INFO: Gathering on-disk MachineConfig from degraded nodes"
+    # we only really need the info from nodes that the MCO has marked as degraded 
+    MACHINECONFIG_DEGRADED_NODES=$(oc get node -o jsonpath='{.items[?(@.metadata.annotations.machineconfiguration\.openshift\.io/state=="Degraded")].metadata.name}')
+    for NODE in ${MACHINECONFIG_DEGRADED_NODES}; do
+         # use the existing MCD pod on the node to get the files
+         DAEMONPOD=$(oc get pods -n openshift-machine-config-operator --field-selector spec.nodeName=${NODE} --selector k8s-app=machine-config-daemon -o custom-columns=:metadata.name --no-headers)
+         # collect the boostrap config that the Node got from the MCS
+         timeout -v 1m oc cp -c machine-config-daemon openshift-machine-config-operator/"${DAEMONPOD}":rootfs/etc/mcs-machine-config-content.json "${MACHINECONFIG_CONFIG_PATH}"/"${NODE}"/mcs-machine-config-content.json &
+         PIDS+=($!)
+    done
+
+}
+
+PIDS=()
+gather_machineconfig_ondisk
+
+echo "INFO: Waiting for on-disk MachineConfig collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: on-disk MachineConfig config collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_metallb
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_metallb
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+BASE_COLLECTION_PATH="must-gather"
+get_operator_ns "metallb-operator"
+get_log_collection_args
+METALLB_PODS_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}/pods"
+
+function get_metallb_crs() {
+    declare -a METALLB_CRDS=("bgppeers" "bfdprofiles" "bgpAdvertisements" "ipaddresspools" "l2advertisements" "communities" "frrconfiguration" "frrnodestate")
+
+    for CRD in "${METALLB_CRDS[@]}"; do
+        oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" -n ${operator_ns} "${CRD}"
+    done
+}
+
+function gather_frr_logs() {
+    declare -a FILES_TO_GATHER=("frr.conf" "frr.log" "daemons" "vtysh.conf")
+    declare -a COMMANDS=("show running-config" "show bgp ipv4" "show bgp ipv6" "show bgp neighbor" "show bfd peer")
+    LOGS_DIR="${METALLB_PODS_PATH}/${1}/frr/frr/logs"
+
+    for FILE in "${FILES_TO_GATHER[@]}"; do
+        oc -n ${operator_ns} exec ${1} -c frr -- sh -c "cat /etc/frr/${FILE}" > ${LOGS_DIR}/${FILE}
+    done
+
+    for COMMAND in "${COMMANDS[@]}"; do
+        echo "###### ${COMMAND}" >> ${LOGS_DIR}/dump_frr
+        echo "$( timeout -v 20s oc -n ${operator_ns} exec ${1} -c frr -- vtysh -c "${COMMAND}")" >> ${LOGS_DIR}/dump_frr
+    done
+}
+
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
+get_metallb_crs
+
+
+if ! oc get metallb metallb -n ${operator_ns} > /dev/null 2>&1; then
+    echo "metallb not started"
+    exit 0
+fi
+
+BGP_BACKEND=$(oc get metallb metallb -n ${operator_ns} -o jsonpath='{.spec.bgpBackend}')
+
+if [ "$BGP_BACKEND" == "frr-k8s" ]; then
+	FRR_PODS="${@:-$(oc -n ${operator_ns} get pods -l component=frr-k8s -o jsonpath='{.items[*].metadata.name}')}"
+else
+	FRR_PODS="${@:-$(oc -n ${operator_ns} get pods -l component=speaker -o jsonpath='{.items[*].metadata.name}')}"
+fi
+PIDS=()
+
+for POD in ${FRR_PODS[@]}; do
+    gather_frr_logs ${POD} &
+    PIDS+=($!)
+    oc -n ${operator_ns} exec ${POD} -c reloader -- sh -c "cat /etc/frr_reloader/reloader.pid" > \
+    ${METALLB_PODS_PATH}/${POD}/reloader/reloader/logs/reloader.pid &
+    PIDS+=($!)
+done
+wait ${PIDS[@]}
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_monitoring
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_monitoring
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# global readonly constants
+declare -r BASE_COLLECTION_PATH="../must-gather"
+declare -r MONITORING_PATH="${BASE_COLLECTION_PATH}/monitoring"
+declare -r CA_BUNDLE="${MONITORING_PATH}/ca-bundle.crt"
+
+
+# init initializes global variables that need to be computed.
+# E.g. get token of the default ServiceAccount
+init() {
+  mkdir -p "${MONITORING_PATH}"
+
+  PROMETHEUS_ROUTE="$(oc get routes \
+    -n openshift-monitoring prometheus-k8s \
+    -o jsonpath='{.status.ingress[0].host}')"
+
+  ALERT_MANAGER_ROUTE="$(oc get routes \
+    -n openshift-monitoring alertmanager-main \
+    -o jsonpath='{.status.ingress[0].host}')"
+
+  # the SA token is used for authentication with Prometheus and Alert Manager
+  # see: prom_get
+  SA_TOKEN="$(oc create token default)"
+
+  # this is a CA bundle we need to verify the monitoring route,
+  # we will write it to disk so we can use it in the flag
+  oc -n openshift-config-managed get cm default-ingress-cert \
+    -o jsonpath='{.data.ca-bundle\.crt}' > "$CA_BUNDLE"
+
+  readarray -t PROM_PODS < <(
+    oc get pods -n openshift-monitoring  -l prometheus=k8s \
+      --no-headers -o custom-columns=":metadata.name"
+  )
+}
+
+cleanup() {
+  rm "$CA_BUNDLE"
+}
+
+# prom_get makes http GET requests to prometheus /api/v1/$object and stores
+# the stdout and stderr results
+prom_get() {
+  local object="$1"; shift
+  local path="${1:-$object}"; shift || true
+
+  local result_path="$MONITORING_PATH/prometheus/$path"
+  mkdir -p "$(dirname "$result_path")"
+
+  oc get \
+    --certificate-authority="$CA_BUNDLE" \
+    --token="${SA_TOKEN}" \
+    --server="https://$PROMETHEUS_ROUTE" \
+    --raw="/api/v1/$object" \
+      > "$result_path.json" \
+      2> "$result_path.stderr"
+}
+
+# prom_get_from_replica makes http GET requests to prometheus pod $replica
+# /api/v1/$object and stores the stdout and stderr results
+prom_get_from_replica() {
+  local replica="$1"; shift
+  local object="$1"; shift
+  local path="${1:-$object}"; shift || true
+
+  local result_path="${MONITORING_PATH}/prometheus/${path}"
+  mkdir -p "$(dirname "${result_path}")"
+
+  oc exec "${replica}" \
+    -c prometheus \
+    -n openshift-monitoring \
+    -- /bin/bash -c "curl -sG http://localhost:9090/api/v1/${object}" \
+      >  "${result_path}.json" \
+      2> "${result_path}.stderr"
+}
+
+prom_get_from_replicas() {
+  local object="$1"; shift
+  local path="${1:-$object}"; shift || true
+
+  for pod in "${PROM_PODS[@]}"; do
+    prom_get_from_replica "${pod}" "${object}" "${pod}/${path}" || true
+  done
+}
+
+alertmanager_get() {
+  local object="$1"; shift
+  local path="${1:-$object}"; shift || true
+
+  local result_path="$MONITORING_PATH/alertmanager/$path"
+  mkdir -p "$(dirname "$result_path")"
+
+  oc get \
+    --certificate-authority="$CA_BUNDLE" \
+    --token="${SA_TOKEN}" \
+    --server="https://$ALERT_MANAGER_ROUTE" \
+    --raw="/api/v2/$object" \
+      > "$result_path.json" \
+      2> "$result_path.stderr"
+}
+
+
+monitoring_gather(){
+  init
+
+  echo "INFO: Found ${#PROM_PODS[@]} replicas - ${PROM_PODS[*]}"
+
+  # begin gathering
+  # NOTE || true ignores failures
+
+  prom_get alertmanagers   || true
+  prom_get rules    || true
+  prom_get status/config  || true
+  prom_get status/flags  || true
+  prom_get status/runtimeinfo  || true
+
+  # using prom_get_from_replica as the state differs for each replica
+  prom_get_from_replicas 'targets?state=active' active-targets  || true
+  prom_get_from_replicas status/tsdb  || true
+
+  alertmanager_get status  || true
+
+  # force disk flush to ensure that all data gathered are written
+  sync
+
+  cleanup
+}
+
+monitoring_gather

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_multus_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_multus_logs
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Expects a space-delimited list of nodes to be passed as parameters.
+
+BASE_COLLECTION_PATH="must-gather"
+NETWORK_LOG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/network_logs"}
+INPUT_LOG_PATH="/host/var/run/multus/cni/net.d/multus.log"
+OUTPUT_LOG_PATH=${OUT:-"${NETWORK_LOG_PATH}/multus_logs"}
+mkdir -p "${OUTPUT_LOG_PATH}"/
+
+function gather_multus_logs {
+  for NODE in "$@"; do
+    nodefilename=$(echo "$NODE" | sed -e 's|node/||')
+    out=$(oc debug "${NODE}" -- \
+    /bin/bash -c "cat $INPUT_LOG_PATH" 2>/dev/null) && echo "$out" 1> "${OUTPUT_LOG_PATH}/multus-log-$nodefilename.log"
+  done
+}
+
+gather_multus_logs $@

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_network_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_network_logs
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# start off by doing a gather, which includes gather_network_logs_basics.
+/usr/bin/gather
+
+BASE_COLLECTION_PATH="must-gather"
+NETWORK_LOG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/network_logs"}
+OVNK_EXTRAS_STORE_PATH=${OUT:-"ovnk_extras_store"}
+
+mkdir -p "${NETWORK_LOG_PATH}"/
+
+function gather_extra_ovn_kubernetes_data_interconnect_mode {
+  echo "INFO: Gathering ovn-kubernetes extra logs"
+  OVNKUBE_CONTROLLER_PODS=($(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}'))
+  # collect additional ovnkube logs from each ovnkube-node
+  CONTAINER="ovnkube-controller"
+  for OVNKUBE_CONTROLLER_POD in "${OVNKUBE_CONTROLLER_PODS[@]}"; do
+    echo "INFO: Gathering "${CONTAINER}" extra logs from "${OVNKUBE_CONTROLLER_POD}"..."
+    DEST_DIR="${NETWORK_LOG_PATH}/${OVNK_EXTRAS_STORE_PATH}/${OVNKUBE_CONTROLLER_POD}/${CONTAINER}"
+    mkdir -p "${DEST_DIR}"
+
+    # Inside the container, execute a 'find' command to identify the desired log files.
+    # Then, pipe the list into a tar file, creating a tarball to be sent to stdout.
+    # This tarball is then untarred while stripping the top 3 directories (var, log, ovnkube),
+    # and the contents are placed into the destination directory for the specified pod and container.
+    # All of this is done in the background.
+    oc exec -n openshift-ovn-kubernetes -c ${CONTAINER} ${OVNKUBE_CONTROLLER_POD} -- \
+       bash -c 'find /var/log/ovnkube -type f -name "libovsdb*log*" | tar czf - -T -' | \
+        tar xzf - -C ${DEST_DIR} --strip-components=3 2>&1 & PIDS+=($!)
+  done
+}
+
+function gather_extra_ovn_kubernetes_data {
+  sample_node=$(oc get no -o jsonpath='{.items[0].metadata.name}')
+  sample_node_zone=$(oc get node "${sample_node}" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/zone-name}')
+  # determine if ovn cluster is running in interconnect mode
+  if [ "${sample_node}" = "${sample_node_zone}" ]; then
+    gather_extra_ovn_kubernetes_data_interconnect_mode
+  fi
+}
+
+PIDS=()
+NETWORK_TYPE=$(oc get network.config.openshift.io -o=jsonpath='{.items[0].spec.networkType}' | tr '[:upper:]' '[:lower:]')
+
+if [[ "${NETWORK_TYPE}" != "ovnkubernetes" ]]; then
+    exit 0
+fi
+
+gather_extra_ovn_kubernetes_data
+echo "INFO: Waiting for ovnk extra logs copies to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: Copying ovnk extra logs complete."
+du -sh "${NETWORK_LOG_PATH}/${OVNK_EXTRAS_STORE_PATH}"
+tar zcvf "${NETWORK_LOG_PATH}/${OVNK_EXTRAS_STORE_PATH}.tar.gz" -C "${NETWORK_LOG_PATH}" "${OVNK_EXTRAS_STORE_PATH}" --remove-files 2>&1
+echo "INFO: Extra network logs collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_network_logs_basics
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_network_logs_basics
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="must-gather"
+NETWORK_LOG_PATH=${OUT:-"${BASE_COLLECTION_PATH}/network_logs"}
+OVNK_DATABASE_STORE_PATH=${OUT:-"ovnk_database_store"}
+
+mkdir -p "${NETWORK_LOG_PATH}"/
+
+function gather_multus_data {
+  local resources=(ippools.whereabouts.cni.cncf.io overlappingrangeipreservations.whereabouts.cni.cncf.io \
+      net-attach-def multi-networkpolicy)
+
+  for resource in "${resources[@]}"; do
+    oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${resource}" --all-namespaces 2>&1 || true & PIDS+=($!)
+    oc describe "${resource}" -A > "${NETWORK_LOG_PATH}"/"${resource}" 2>&1 || true & PIDS+=($!)
+  done
+}
+
+READY_CONTROL_PLANE_NODES="${@:-$(oc get node -l node-role.kubernetes.io/control-plane -o json | jq -r '.items[] | select(.status.conditions[] | select(.type=="Ready" and .status=="True")).metadata.name')}"
+
+/usr/bin/gather_multus_logs $READY_CONTROL_PLANE_NODES
+
+function gather_ovn_kubernetes_data_interconnect_mode {
+  echo "INFO: Gathering ovn-kubernetes DBs"
+  OVNKUBE_CONTROLLER_PODS=($(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}'))
+  # collect dbs from each node
+  for DB in "n" "s"; do
+    if [ "$DB" = "n" ]; then
+      DB_NAME="OVN_Northbound"
+      CONTAINER="nbdb"
+    else
+      DB_NAME="OVN_Southbound"
+      CONTAINER="sbdb"
+    fi
+    for OVNKUBE_CONTROLLER_POD in "${OVNKUBE_CONTROLLER_PODS[@]}"; do
+      echo "INFO: Gathering "${DB_NAME}" from "${OVNKUBE_CONTROLLER_POD}"..."
+      oc cp openshift-ovn-kubernetes/"${OVNKUBE_CONTROLLER_POD}":/etc/ovn/ovn"${DB}"b_db.db -c "${CONTAINER}" \
+        "${NETWORK_LOG_PATH}/${OVNK_DATABASE_STORE_PATH}/${OVNKUBE_CONTROLLER_POD}_${DB}bdb" 2>&1 & PIDSDB+=($!)
+    done
+  done
+}
+
+function gather_ovn_kubernetes_data_legacy_mode {
+  echo "INFO: Gathering ovn-kubernetes master data"
+  OVNKUBE_MASTER_PODS=($(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-master -o=jsonpath='{.items[*].metadata.name}'))
+  # collect only leader dbs to reduce result size
+  for DB in "n" "s"; do
+    if [ "$DB" = "n" ]; then
+      DB_NAME="OVN_Northbound"
+      CONTAINER="nbdb"
+    else
+      DB_NAME="OVN_Southbound"
+      CONTAINER="sbdb"
+    fi
+    i=0
+    PODS_AMOUNT=${#OVNKUBE_MASTER_PODS[@]}
+    # try 2 cycles in case leader has changed during first pass
+    while (( i < 2 * PODS_AMOUNT )) ; do
+      OVNKUBE_MASTER_POD=${OVNKUBE_MASTER_PODS[$(( i % PODS_AMOUNT ))]}
+      # find leader to copy db
+      RAFT_ROLE=$(oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c "${CONTAINER}" -- bash -c \
+        "ovn-appctl -t /var/run/ovn/ovn${DB}b_db.ctl cluster/status ${DB_NAME} 2>&1 | grep \"^Role\"")
+      if echo "${RAFT_ROLE}" | grep -q -i leader; then
+        oc cp openshift-ovn-kubernetes/"${OVNKUBE_MASTER_POD}":/etc/ovn/ovn"${DB}"b_db.db -c "${CONTAINER}" \
+         "${NETWORK_LOG_PATH}/leader_${DB}bdb" 2>&1
+        gzip "${NETWORK_LOG_PATH}/leader_${DB}bdb" 2>&1 & PIDS+=($!)
+
+        oc exec -n openshift-ovn-kubernetes "${OVNKUBE_MASTER_POD}" -c "${CONTAINER}" -- bash -c \
+          "ovn-appctl -t /var/run/ovn/ovn${DB}b_db.ctl cluster/status ${DB_NAME}" > \
+          "${NETWORK_LOG_PATH}/leader_ovn${DB}b_status" & PIDS+=($!)
+        break
+      fi
+      ((i++))
+    done
+  done
+}
+
+function gather_ovn_kubernetes_data {
+  sample_node=$(oc get no -o jsonpath='{.items[0].metadata.name}')
+  sample_node_zone=$(oc get node "${sample_node}" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/zone-name}')
+  if [ "${sample_node}" = "${sample_node_zone}" ]; then
+    echo "INFO: INTERCONNECT MODE"
+    gather_ovn_kubernetes_data_interconnect_mode
+  else
+    echo "INFO: LEGACY MODE"
+    gather_ovn_kubernetes_data_legacy_mode
+  fi
+
+  oc adm top pods -n openshift-ovn-kubernetes --containers > "${NETWORK_LOG_PATH}"/ovn_kubernetes_top_pods & PIDS+=($!)
+}
+
+function gather_scale_data {
+  touch "${NETWORK_LOG_PATH}"/cluster_scale
+  echo services amount: $(oc get svc --no-headers -A | wc -l) >> "${NETWORK_LOG_PATH}"/cluster_scale & PIDS+=($!)
+  echo endpoints amount: $(oc get ep --no-headers -A | wc -l) >> "${NETWORK_LOG_PATH}"/cluster_scale & PIDS+=($!)
+  echo pods amount: $(oc get pods --no-headers -A | wc -l) >> "${NETWORK_LOG_PATH}"/cluster_scale & PIDS+=($!)
+  echo network policies amount: $(oc get networkpolicies --no-headers -A | wc -l) >> "${NETWORK_LOG_PATH}"/cluster_scale & PIDS+=($!)
+  if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
+    echo egress firewalls amount: $(oc get egressfirewalls --no-headers -A | wc -l) >> "${NETWORK_LOG_PATH}"/cluster_scale & PIDS+=($!)
+  fi
+}
+
+PIDS=()
+PIDSDB=()
+NETWORK_TYPE=$(oc get network.config.openshift.io -o=jsonpath='{.items[0].spec.networkType}' | tr '[:upper:]' '[:lower:]')
+
+gather_multus_data
+gather_scale_data
+
+if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
+    oc adm inspect ${log_collection_args} --dest-dir must-gather egressips.k8s.ovn.org
+    oc adm inspect ${log_collection_args} --dest-dir must-gather adminnetworkpolicies.policy.networking.k8s.io
+    oc adm inspect ${log_collection_args} --dest-dir must-gather baselineadminnetworkpolicies.policy.networking.k8s.io
+    gather_ovn_kubernetes_data
+elif [[ "${NETWORK_TYPE}" == "openshiftsdn" ]]; then
+    oc adm inspect ${log_collection_args} --dest-dir must-gather hostsubnets.network.openshift.io
+fi
+
+CNCC_DEPLOYMENT=$(oc get deployment -n openshift-cloud-network-config-controller --no-headers -o custom-columns=":metadata.name")
+if [[ "${CNCC_DEPLOYMENT}" == "cloud-network-config-controller" ]]; then
+  oc adm inspect ${log_collection_args} --dest-dir must-gather cloudprivateipconfigs.cloud.network.openshift.io
+fi
+
+echo "INFO: Waiting for network log collection to complete ..."
+if [[ "${NETWORK_TYPE}" == "ovnkubernetes" ]]; then
+    echo "INFO: Waiting for ovnk database copies to complete ..."
+    wait "${PIDSDB[@]}"
+    echo "INFO: Copying ovnk databases complete."
+    du -sh "${NETWORK_LOG_PATH}/${OVNK_DATABASE_STORE_PATH}"
+    tar -zcvf "${NETWORK_LOG_PATH}/${OVNK_DATABASE_STORE_PATH}.tar.gz" -C "${NETWORK_LOG_PATH}" "${OVNK_DATABASE_STORE_PATH}" --remove-files 2>&1 & PIDS+=($!)
+fi
+wait "${PIDS[@]}"
+echo "INFO: Network log collection complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_nmstate
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_nmstate
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+BASE_COLLECTION_PATH="must-gather"
+get_operator_ns "kubernetes-nmstate-operator"
+get_log_collection_args
+
+function get_nmstate_crs() {
+    declare -a NMSTATE_CRDS=("nmstates" "nodenetworkconfigurationenactments" "nodenetworkconfigurationpolicies" "nodenetworkstates")
+
+    for CRD in "${NMSTATE_CRDS[@]}"; do
+        oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "${CRD}"
+    done
+}
+
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" "ns/${operator_ns}"
+get_nmstate_crs
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_olm
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_olm
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+oc adm inspect ${log_collection_args} --dest-dir=must-gather -A olm

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_podnetworkconnectivitycheck
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_podnetworkconnectivitycheck
@@ -1,0 +1,7 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="/must-gather"
+POD_NETWORK_CHECK="${BASE_COLLECTION_PATH}/pod_network_connectivity_check/"
+
+mkdir -p ${POD_NETWORK_CHECK}
+
+oc get podnetworkconnectivitychecks -n openshift-network-diagnostics -o yaml > ${POD_NETWORK_CHECK}/podnetworkconnectivitychecks.yaml

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_ppc
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_ppc
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="must-gather"
+NODES_PATH=${BASE_COLLECTION_PATH}/nodes
+
+# Once you start the pod, the Kubernetes will set the pod hostname to the name of the pod
+# https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+POD_NAME=${HOSTNAME}
+POD_IP=$(hostname -I |  tr -d "[:blank:]" )
+
+function check_node_gather_pods_ready() {
+  line=$(oc get ds perf-node-gather-daemonset -o=custom-columns=DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady --no-headers -n $NAMESPACE)
+
+  IFS=$' '
+  read desired ready <<< $line
+  IFS=$'\n'
+
+  if [[ "$desired" != "0" ]] && [[ "$ready" == "$desired" ]]
+  then
+    echo "Daemonset perf-node-gather-daemonset ready $ready out of $desired"
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Start a specially privileged pod on each node and collect node level performance tuning data
+function ppc_nodes() {
+  IFS=$'\n'
+
+  # Create the destination
+  mkdir -p ${NODES_PATH}
+
+  # Save the debug pod info
+  echo "[$NAMESPACE/$POD_IP/$POD_NAME]" >> ${NODES_PATH}/debug
+  oc get pod -n $NAMESPACE $POD_NAME -o json >> ${NODES_PATH}/debug
+
+  # Find the NTO image reference
+  # NTO contains all the tools needed here
+  NTO=$(oc get deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator -o jsonpath="{.spec.template.spec.containers[0].image}")
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to identify the container image with node tools."
+    echo "INFO: Node performance data collection will not contain node level data."
+    return
+  fi
+
+  echo "INFO: Image with low level tools to use: ${NTO}"
+
+  # Start the collection daemon set
+  cat << EOF | oc apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: perf-node-gather-daemonset
+  namespace: ${NAMESPACE}
+  labels:
+spec:
+  selector:
+    matchLabels:
+      name: perf-node-gather-daemonset
+  template:
+    metadata:
+      labels:
+        name: perf-node-gather-daemonset
+    spec:
+      # some gathering tools wants to collect (non-sensitive) informations about *all*
+      # the processes running on a worker nodes, like thread count and CPU affinity of
+      # them. Hence, we need to be able to see all the processes on the node.
+      hostPID: true
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: node-probe
+        image: ${NTO}
+        command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "100m"
+            memory: "256Mi"
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: sys
+            mountPath: /host/sys
+            readOnly: true
+          - name: proc
+            mountPath: /host/proc
+            readOnly: true
+          # this is needed for lspci
+          - name: lib-modules
+            mountPath: /lib/modules
+            readOnly: true
+          # Pod resources API is an endpoint that has to be
+          # writable so we can request current status
+          - name: podres
+            mountPath: /host/podresources
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: proc
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: podres
+        hostPath:
+          path: /var/lib/kubelet/pod-resources
+          type: Directory
+      tolerations: 
+        - operator: Exists
+EOF
+
+  COUNTER=0
+  until check_node_gather_pods_ready || [ $COUNTER -eq 300 ]; do
+     (( COUNTER++ ))
+     echo "Waiting for performance profile collector pods to become ready: $COUNTER"
+     sleep 1
+  done
+
+  for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName --no-headers -l name=perf-node-gather-daemonset --field-selector=status.phase!=Running -n $NAMESPACE)
+  do
+      echo "Failed to collect performance data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
+  done
+
+  COLLECTABLE_NODES=()
+  NODE_PIDS=()
+  for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers -l name=perf-node-gather-daemonset --field-selector=status.phase=Running -n $NAMESPACE)
+  do
+      node=$(echo $line | awk -F ' ' '{print $1}')
+      pod=$(echo $line | awk -F ' ' '{print $2}')
+      NODE_PATH=${NODES_PATH}/$node
+      mkdir -p "${NODE_PATH}"
+
+      COLLECTABLE_NODES+=($node)
+
+      # Run per node data collection in parallel
+      timeout -k 1m 5m /usr/bin/gather_ppc_single_node "${pod}" "${NAMESPACE}" "${node}" "${NODE_PATH}" &
+      NODE_PIDS+=($!)
+  done
+  wait "${NODE_PIDS[@]}"
+
+  # Collect journal logs for specified units for all nodes
+  NODE_UNITS=(kubelet)
+  ADM_PIDS=()
+  for NODE in ${COLLECTABLE_NODES[@]}; do
+      NODE_PATH=${NODES_PATH}/$NODE
+      mkdir -p ${NODE_PATH}
+      for UNIT in ${NODE_UNITS[@]}; do
+          echo "Collecting ${UNIT} logs for node ${NODE}"
+          timeout -k 5m 30m bash -c "oc adm node-logs \"${node_log_collection_args:---since=-8h}\" $NODE -u $UNIT | gzip" > ${NODE_PATH}/${NODE}_logs_$UNIT.gz &
+          ADM_PIDS+=($!)
+      done
+  done
+  wait "${ADM_PIDS[@]}"
+
+  oc delete ds perf-node-gather-daemonset -n $NAMESPACE
+}
+
+#
+# The main section follows
+#
+
+
+# resource list
+resources=()
+
+# performance operator profiles
+resources+=(performanceprofile)
+
+# machine/node resources
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds runtimeclasses)
+
+echo "INFO: Waiting for node performance related collection to complete ..."
+
+# run the collection of resources using must-gather
+for resource in ${resources[@]}; do
+  oc adm inspect ${log_collection_args} --dest-dir must-gather --all-namespaces ${resource}
+done
+
+# Collect nodes details
+ppc_nodes
+
+echo "INFO: Node performance data collection complete."
+
+exit 0

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_ppc_single_node
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_ppc_single_node
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is not supposed to be executed manually. It is used from
+# the gather_ppc collection script.
+
+pod=$1
+NAMESPACE=$2
+node=$3
+NODE_PATH=$4
+
+echo "Collecting performance related data for node $node"
+
+oc exec $pod -n $NAMESPACE -- lspci -nvv > $NODE_PATH/lspci
+oc exec $pod -n $NAMESPACE -- lscpu -e > $NODE_PATH/lscpu
+oc exec $pod -n $NAMESPACE -- cat /proc/cmdline > $NODE_PATH/proc_cmdline
+oc exec $pod -n $NAMESPACE -- dmesg > $NODE_PATH/dmesg
+oc exec $pod -n $NAMESPACE -- ethtool -k eth0 > $NODE_PATH/ethtool_features
+oc exec $pod -n $NAMESPACE -- ethtool -l eth0 > $NODE_PATH/ethtool_channels
+
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json cpuaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/cpu_affinities.json
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json irqaff --procfs=/host/proc --sysfs=/host/sys > $NODE_PATH/irq_affinities.json
+oc exec $pod -n $NAMESPACE -- gather-sysinfo --json podres --socket-path=unix:///host/podresources/kubelet.sock > $NODE_PATH/podresources.json
+
+oc exec $pod -n $NAMESPACE -- gather-sysinfo snapshot --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
+oc exec $pod -n $NAMESPACE -- gather-sysinfo podinfo --node-name $node > $NODE_PATH/pods_info.json

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_priority_and_fairness
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_priority_and_fairness
@@ -1,0 +1,83 @@
+#!/bin/bash
+# We don't want to collect /debug/api_priority_and_fairness in oc adm inspect,
+# https://github.com/openshift/oc/blob/master/pkg/cli/admin/inspect/pod.go#L58-L62
+# because the tokens could be used in a replay attack,
+# thus the route we are taking here is forced by this.
+
+# Safeguards
+set -o nounset
+set -o errexit
+set -o pipefail
+
+BASE_COLLECTION_PATH="/must-gather"
+NAMESPACE_PATH="namespaces/openshift-kube-apiserver"
+POD_PATH="kube-apiserver/kube-apiserver/api_priority_and_fairness"
+APF_PATH="${BASE_COLLECTION_PATH}/${NAMESPACE_PATH}"
+
+# If the cluster version is < 4.6 skip this test
+
+# If cluster version is >=4.6 then the COMPARE will always == 4.6
+#  For example cluster version 4.7:
+#  VERSION=4.7
+#  COMPARE=$(echo -e "4.6\n${VERSION}" | sort -V | head -n1)
+#  echo $COMPARE
+#  4.6
+
+# If cluster version is <4.6 then the COMPARE will be the always the cluster version.
+#  VERSION=4.4
+#  COMPARE=$(echo -e "4.6\n${VERSION}" | sort -V | head -n1)
+#  echo $COMPARE
+#  4.4
+
+VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
+COMPARE=$(echo -e "4.6\n${VERSION}" | sort -V | head -n1)
+if [[ ${COMPARE} != "4.6" ]]; then
+  echo "INFO: Cluster version is ${VERSION}. Skipping."
+  exit 0
+fi
+
+# Fetches the POD_NAME where app label is apiserver.
+# Example:
+#  oc get po -n openshift-kube-apiserver -l apiserver -o jsonpath='{.items[*].metadata.name}'
+#  kube-apiserver-master-0.example.com kube-apiserver-master-1.example.com kube-apiserver-master-2.example.com
+KUBE_API_SERVERS=$(oc get po -n openshift-kube-apiserver -l apiserver -o jsonpath='{.items[*].metadata.name}')
+if [[ -z ${KUBE_API_SERVERS} ]]; then
+    echo "ERROR: No running kube-apiserver pods found" >&2
+    exit 1
+fi
+
+for API_SERVER in ${KUBE_API_SERVERS}
+do
+  OUTPUT_DIR="${APF_PATH}/pods/${API_SERVER}/${POD_PATH}"
+  mkdir -p "${OUTPUT_DIR}"
+
+  # Fetches the POD_IP from the apiserver pod.
+  # Example:
+  #  oc get po -n openshift-kube-apiserver kube-apiserver-master-0.example.com -o jsonpath='{.status.podIP}'
+  #  192.168.9.43
+  POD_IP=$(oc get po -n openshift-kube-apiserver "${API_SERVER}" -o jsonpath='{.status.podIP}')
+  if [[ -z ${POD_IP} ]]; then
+      echo "ERROR: ${API_SERVER}: unable to get .status.podIP" >&2
+      continue
+  fi
+
+  # Fetches the POD_PORT where container name is kube-apiserver.
+  # Example:
+  #  oc get po -n openshift-kube-apiserver kube-apiserver-master-0.example.com -o jsonpath='{.spec.containers[?(.name=="kube-apiserver")].ports[0].hostPort}'
+  #  6443
+  POD_PORT=$(oc get po -n openshift-kube-apiserver "${API_SERVER}" -o jsonpath='{.spec.containers[?(.name=="kube-apiserver")].ports[0].hostPort}')
+  if [[ -z ${POD_PORT} ]]; then
+      echo "ERROR: ${API_SERVER}: unable to get .spec.containers.ports[0].hostPort" >&2
+      continue
+  fi
+
+  echo "INFO: Collecting /debug/api_priority_and_fairness endpoint from ${API_SERVER}"
+
+  oc get --raw https://"${POD_IP}":"${POD_PORT}"/debug/api_priority_and_fairness/dump_priority_levels \
+               > "${OUTPUT_DIR}"/priority_levels
+  oc get --raw https://"${POD_IP}":"${POD_PORT}"/debug/api_priority_and_fairness/dump_queues \
+               > "${OUTPUT_DIR}"/queues
+  oc get --raw https://"${POD_IP}":"${POD_PORT}"/debug/api_priority_and_fairness/dump_requests \
+               > "${OUTPUT_DIR}"/requests
+
+done

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_profiling_node
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_profiling_node
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-must-gather}"
+PROFILING_NODE_LOG_PATH="${BASE_COLLECTION_PATH}/pprof"
+PROFILING_NODE_KUBELET_LOG_PATH="${PROFILING_NODE_LOG_PATH}/kubelet"
+PROFILING_NODE_CRIO_LOG_PATH="${PROFILING_NODE_LOG_PATH}/crio"
+
+PROFILING_NODE_APISERVER="kubernetes.default.svc"
+PROFILING_NODE_SECONDS="${PROFILING_NODE_SECONDS:-30}"
+PROFILING_NODE_TARGET="${PROFILING_NODE_TARGET:-ALL}"
+
+PROFILING_NODE_IMAGE="${PROFILING_NODE_IMAGE:-"registry.redhat.io/rhel8/support-tools"}"
+
+# _gather_profiling_node_node_exists $NODE
+# returns "true" if $NODE is found among the cluster nodes, "false" otherwise.
+_gather_profiling_node_node_exists() {
+    local node="$1"
+
+    oc get node "$node" > /dev/null 2>&1
+    return "$?"
+}
+
+# _gather_profiling_node_is_apiserver_available
+# returns "true" if the kubernetes apiserver can be reached, returns "false" otherwise.
+_gather_profiling_node_is_apiserver_available() {
+    oc get --raw https://${PROFILING_NODE_APISERVER}/api > /dev/null 2>&1
+    return "$?"
+}
+
+_gather_profiling_node_start_crio_collection_pod() {
+    local node="$1"
+    local pod_name="$2"
+
+    cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod_name}
+  labels:
+    name: gather-profiling-crio
+spec:
+  restartPolicy: Never
+  nodeName: ${node}
+  containers:
+  - name: crio-prof-expose
+    image: ${PROFILING_NODE_IMAGE}
+    command: ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"]
+    volumeMounts:
+    - mountPath: /tmp/pprof
+      name: pprof-data
+  initContainers:
+  - name: crio-prof-generate
+    image: ${PROFILING_NODE_IMAGE}
+    command: ["/bin/bash", "-c"]
+    args:
+      - curl --unix-socket /run/crio/crio.sock -o /tmp/pprof/${node}_heap.out http://localhost/debug/pprof/heap;
+        curl --unix-socket /run/crio/crio.sock -o /tmp/pprof/${node}_prof.out http://localhost/debug/pprof/profile?seconds=${PROFILING_NODE_SECONDS};
+    securityContext:
+      runAsUser: 0
+      privileged: True
+    volumeMounts:
+    - mountPath: /run/crio/crio.sock
+      name: crio-socket
+    - mountPath: /tmp/pprof
+      name: pprof-data
+  volumes:
+  - name: crio-socket
+    hostPath:
+      path: /run/crio/crio.sock
+  - name: pprof-data
+    emptyDir: {}
+EOF
+}
+
+_gather_profiling_node_collect_crio_data() {
+    local node="$1"
+    local pod_name="pprof.${node}"
+    local extract_timeout=$((PROFILING_NODE_SECONDS+300))
+
+    _gather_profiling_node_start_crio_collection_pod "$node" "$pod_name"
+    if oc wait --for=condition=Ready pod/${pod_name} --timeout=${extract_timeout}s; then
+        oc cp -c crio-prof-expose "${pod_name}:/tmp/pprof/" "$PROFILING_NODE_CRIO_LOG_PATH"
+        oc delete pod "$pod_name"
+    else
+        oc delete pod --grace-period=0 --force "$pod_name"
+    fi
+}
+
+_gather_profiling_node_collect_kubelet_data() {
+    local node="$1"
+    local out_kub_base="${PROFILING_NODE_KUBELET_LOG_PATH}/${node}"
+    local out_kub_heap="${out_kub_base}_heap.out"
+    local out_kub_prof="${out_kub_base}_prof.out"
+    local url_base="https://${PROFILING_NODE_APISERVER}/api/v1/nodes/${node}/proxy/debug/pprof"
+
+    oc get --raw "${url_base}/profile?seconds=${PROFILING_NODE_SECONDS}" > "$out_kub_prof"
+    oc get --raw "${url_base}/heap" > "$out_kub_heap"
+}
+
+_gather_profiling_node_collect_data_loop() {
+    local pids=()
+    local node
+
+    mkdir -p "$PROFILING_NODE_KUBELET_LOG_PATH" "$PROFILING_NODE_CRIO_LOG_PATH"
+    for node in ${NODES}; do
+        if _gather_profiling_node_node_exists "$node"; then
+            if [ "$DO_PROF_CRIO" = true ]; then
+                echo "INFO: start crio profiling task on node ${node}"
+                _gather_profiling_node_collect_crio_data "$node" & pids+=($!)
+            fi
+            if [ "$DO_PROF_KUBELET" = true ]; then
+                echo "INFO: start kubelet profiling task on node ${node}"
+                _gather_profiling_node_collect_kubelet_data "$node" & pids+=($!)
+            fi
+        else
+            echo "ERROR: node ${node} not found in the cluster"
+        fi
+    done
+
+    [ -z "$pids" ] && return
+    echo "INFO: wait for crio/kubelet profiling tasks"
+    wait ${pids[@]}
+}
+
+NODES="${@}"
+if [ -z "$NODES" ]; then
+    echo -e "\nWARNING: since no nodes have been specified for the profiling task, data will\n"\
+            "be collected on ALL the nodes in the cluster. This may take quite some time.\n"
+    NODES="$(oc get nodes -o jsonpath='{.items[?(@.kind=="Node")].metadata.name}')"
+fi
+
+DO_PROF_CRIO=true
+DO_PROF_KUBELET=true
+
+case "$PROFILING_NODE_TARGET" in
+    all | ALL)    ;;
+    crio | CRIO | CRI-O)    DO_PROF_KUBELET=false ;;
+    kubelet | KUBELET)      DO_PROF_CRIO=false ;;
+    *) echo -e "\nWARNING: PROFILING_NODE_TARGET set to unknown value = [$PROFILING_NODE_TARGET].\n"\
+               "allowed values are: 'all' (default), 'crio' or 'kubelet'.\n"
+               "Running with 'all'"
+esac
+
+echo "INFO: GATHER NODE PROFILING DATA [${PROFILING_NODE_SECONDS}s]"
+if _gather_profiling_node_is_apiserver_available; then
+    _gather_profiling_node_collect_data_loop
+else
+    echo "ERROR: failed connecting to the kubernetes apiserver"
+fi
+echo "INFO: gather node profiling data completed"

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_service_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_service_logs
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+. gather_service_logs_util
+
+BASE_COLLECTION_PATH="/must-gather"
+ROLES=${1:-master}         ### Defaults to only collecting things from Masters
+
+# Service Lists
+GENERAL_SERVICES=(crio kubelet rpm-ostreed ostree-finalize-staged machine-config-daemon-firstboot machine-config-daemon-host NetworkManager openvswitch
+                  ovs-configuration ovsdb-server ovs-vswitchd)
+MASTER_SERVICES+=(${2:-"${GENERAL_SERVICES[@]}"})
+MASTER_SERVICES+=()        ### Placeholder to extend Master only services
+NODE_SERVICES+=(${2:-"${GENERAL_SERVICES[@]}"})
+NODE_SERVICES+=()          ### Placeholder to extend Node only services
+
+# Collect System Service Logs
+SERVICE_LOG_PATH="${BASE_COLLECTION_PATH}/host_service_logs/"
+
+# collect service logs expects PIDS to be an already defined array
+PIDS=()
+if [[ $ROLES == "master" ]]; then
+    collect_service_logs --role=master ${MASTER_SERVICES[@]}
+elif [[ $ROLES == "worker" ]]; then
+    collect_service_logs --role=worker ${NODE_SERVICES[@]}
+elif [[ $ROLES == "master,worker" ]] || [[ $ROLES == "worker,master" ]]; then
+    collect_service_logs --role=master ${MASTER_SERVICES[@]}
+    collect_service_logs --role=worker ${NODE_SERVICES[@]}
+else
+    echo "Error: no selector supplied or an invalid selector was supplied." >&2
+    echo "Error: valid selectors are '--role=master', '--role=worker', '--rolemaster,worker', '--role=worker,master' the node name." >&2
+fi
+
+echo "INFO: Waiting for worker host service log collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: Worker host service log collection to complete."
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_service_logs_util
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_service_logs_util
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This file is a library which should never be executed directly.
+# It doesn't have execution rights but if anyone runs it as 
+# `bash gather_service_logs_util` it will return 0 and won't do anything.
+
+function collect_service_logs {
+# Takes a node role input (master or worker) and a list of services
+# assumes there is a SERVICE_LOG_PATH variable defined used to set the logs
+# destination and a PIDS variable which is an array.
+
+    selector=${1}
+    shift
+
+    if [[ ${selector} == '--role=master' ]]; then
+        DIR_PATH="${SERVICE_LOG_PATH}/masters"
+    elif [[ ${selector} == '--role=worker' ]]; then
+        DIR_PATH="${SERVICE_LOG_PATH}/workers"
+        echo "WARNING: Collecting one or more service logs on ALL linux $1 workers in your cluster. This could take a large amount of time." >&2
+    else
+        DIR_PATH="${SERVICE_LOG_PATH}/${selector}"
+    fi
+
+    mkdir -p "${DIR_PATH}"
+    for service in "${@}"; do
+        echo "INFO: Collecting host service logs for $service"
+        if [[ ${selector} =~ '--role=' ]]; then
+            /usr/bin/oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" ${selector} -l kubernetes.io/os=linux -u "${service}"> "${DIR_PATH}/${service}_service.log" &
+	    PIDS+=($!)
+        else
+            /usr/bin/oc adm node-logs "${node_log_collection_args:---since=${SINCE_TIMEFRAME:--7d}}" ${selector} -u "${service}"> "${DIR_PATH}/${service}_service.log" &
+	    PIDS+=($!)
+        fi
+    done
+}

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_sriov
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_sriov
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+BASE_COLLECTION_PATH="must-gather"
+get_operator_ns "sriov-network-operator"
+get_log_collection_args
+SRIOV_LOG_PATH="${BASE_COLLECTION_PATH}/namespaces/${operator_ns}"
+
+# resource list
+resources=()
+
+# sriov network operator namespace
+resources+=(ns/${operator_ns})
+
+# sriovnetwork.openshift.io
+resources+=(sriovnetworknodepolicies sriovnetworknodestates sriovnetworkpoolconfigs sriovnetworks sriovoperatorconfigs sriovibnetworks)
+
+# run the collection of resources using must-gather
+for resource in ${resources[@]}; do
+  oc adm inspect ${log_collection_args} --dest-dir must-gather --all-namespaces ${resource}
+done
+
+CONFIG_DAEMON_PODS="${@:-$(oc -n ${operator_ns} get pods -l app=sriov-network-config-daemon -o jsonpath='{.items[*].metadata.name}')}"
+PIDS=()
+
+# gather_netns_ip_a runs ip netns, and for every net namespace runs `ip netns exec <id> ip a`
+function gather_netns_ip_a(){
+  CONFIG_DAEMON_POD_LOG_PATH="${SRIOV_LOG_PATH}/pods/${1}"
+  NETNS_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/netns"
+  NETNS_IP_A_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/netns_ip_a"
+
+  # Filter out everything after network namespace name
+  oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- chroot /host /bin/bash -c "ip netns | sed "s/ .*//"" > "${NETNS_LOG_PATH}" 2>&1 
+
+  while IFS= read -r id; do  
+    echo "> ip netns exec ${id} ip a" >> "${NETNS_IP_A_LOG_PATH}" &&
+    oc exec -n ${operator_ns} "${1}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "ip netns exec ${id} ip a" >> "${NETNS_IP_A_LOG_PATH}" 2>&1
+  done < "${NETNS_LOG_PATH}"
+}
+
+function gather_ethtool(){
+  CONFIG_DAEMON_POD_LOG_PATH="${SRIOV_LOG_PATH}/pods/${1}"
+  ETHTOOL_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/ethtool"
+
+  # Get ip -o link show output.
+  OUT="$(oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- chroot /host \
+  /bin/bash -c "ip -o link show 2>/dev/null")"
+
+  # Cut long interfaces names.
+  INTERFACES="$(echo "$OUT" | awk -F': ' '{print $2}')"
+
+  # Run ethtool for each interface except for lo.
+  while IFS= read -r interface; do
+    if [ -z "$interface" ] || [ "$interface" = "lo" ] || [[ "$interface" == *"@"* ]]; then
+      continue
+    fi
+    echo "> ethtool -i ${interface}" >> "${ETHTOOL_LOG_PATH}"
+    oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "ethtool -i ${interface}" >> "${ETHTOOL_LOG_PATH}"
+  done <<< "$INTERFACES"
+}
+
+function gather_bf_info(){
+  CONFIG_DAEMON_POD_LOG_PATH="${SRIOV_LOG_PATH}/pods/${1}"
+  MSTCONFIG_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/mstconfig"
+  MSTFLINT_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/mstflint"
+
+  devices=$(oc exec -n openshift-sriov-network-operator ${1} -c sriov-network-config-daemon -- mstconfig q 2>/dev/null | grep "Device:" | awk 'BEGIN {FS="/";} { print $6 }')
+  if [ -z "${devices}" ]; then
+    echo "No Mellanox devices detected by mstconfig" | tee -a "${MSTCONFIG_LOG_PATH}" "${MSTFLINT_LOG_PATH}" >/dev/null;
+    return
+  fi
+  for device in $devices; do
+    oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- \
+    /bin/bash -c "mstconfig -e -d $device q" >> "${MSTCONFIG_LOG_PATH}"
+
+    oc exec -n ${operator_ns} ${1} -c sriov-network-config-daemon -- \
+    /bin/bash -c "mstflint -d $device q" >> "${MSTFLINT_LOG_PATH}"
+  done
+}
+
+for CONFIG_DAEMON_POD in ${CONFIG_DAEMON_PODS[@]}; do
+
+    CONFIG_DAEMON_POD_LOG_PATH="${SRIOV_LOG_PATH}/pods/${CONFIG_DAEMON_POD}"
+    SNO_INITIAL_NODE_STATE_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/sno-initial-node-state.json"
+    KERNEL_CMDLINE_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/kernel-cmdline"
+    IP_LINK_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/ip_link"
+    DMESG_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/dmesg"
+    MULTUS_LOG_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/multus-log"
+    VAR_LIB_CNI_SRIOV_PATH="${CONFIG_DAEMON_POD_LOG_PATH}/var-lib-cni-sriov"
+
+    # Collect sno-initial-node-state.json.
+    oc exec -n ${operator_ns} "${CONFIG_DAEMON_POD}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "cat /tmp/sno-initial-node-state.json" > ${SNO_INITIAL_NODE_STATE_LOG_PATH} & PIDS+=($!)
+    
+    # Collect kernel cmdline.
+    oc exec -n ${operator_ns} "${CONFIG_DAEMON_POD}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "cat /proc/cmdline" > "${KERNEL_CMDLINE_LOG_PATH}" & PIDS+=($!)
+    
+    # Collect ip link.
+    oc exec -n ${operator_ns} "${CONFIG_DAEMON_POD}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "ip link" > "${IP_LINK_LOG_PATH}"  2>&1  & PIDS+=($!) 
+
+    # Collect dmesg.
+    oc exec -n ${operator_ns} "${CONFIG_DAEMON_POD}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "journalctl -k" > "${DMESG_LOG_PATH}" & PIDS+=($!)
+    
+    # Collect var/log/multus.log if exists.
+    out=$(oc exec -n ${operator_ns} "${CONFIG_DAEMON_POD}" -c sriov-network-config-daemon -- chroot /host \
+    /bin/bash -c "cat var/log/multus.log" 2>/dev/null) && echo "$out" 1> "${MULTUS_LOG_PATH}" & PIDS+=($!)
+
+    # Collect /var/lib/cni/sriov contents.
+    oc cp -n ${operator_ns} -c sriov-network-config-daemon "${CONFIG_DAEMON_POD}":/host/var/lib/cni/sriov "${VAR_LIB_CNI_SRIOV_PATH}" & PIDS+=($!)
+
+    gather_netns_ip_a "${CONFIG_DAEMON_POD}"  & PIDS+=($!)
+
+    gather_ethtool "${CONFIG_DAEMON_POD}"  & PIDS+=($!)
+
+    gather_bf_info "${CONFIG_DAEMON_POD}"  & PIDS+=($!)
+    
+done 
+
+echo "INFO: Waiting for sriov info collection to complete ..."
+wait "${PIDS[@]}"
+echo "INFO: sriov info collection complete."
+
+# force disk flush to ensure that all data gathered are written
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_vsphere
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_vsphere
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="must-gather"
+
+CSIDRIVER=$( /usr/bin/oc get clustercsidriver csi.vsphere.vmware.com --ignore-not-found=true )
+if [ -z "$CSIDRIVER" ]; then
+    # vSphere CSI driver is not installed, most probably this is not vSphere platform
+    exit 0
+fi
+
+echo "INFO: Collecting vSphere CSI driver CRDs"
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" --rotated-pod-logs csinodetopologies.cns.vmware.com,cnsvspherevolumemigrations.cns.vmware.com
+oc adm inspect ${log_collection_args} --dest-dir "${BASE_COLLECTION_PATH}" --rotated-pod-logs --all-namespaces cnsvolumeoperationrequests.cns.vmware.com
+
+echo "INFO: Collecting vSphere CSI driver CRDs complete"
+
+# force disk flush to ensure that all data gathered are written
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/gather_windows_node_logs
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/gather_windows_node_logs
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+source $(dirname "$0")/common.sh
+get_log_collection_args
+
+BASE_COLLECTION_PATH="/must-gather"
+WINDOWS_NODE_LOGS=$BASE_COLLECTION_PATH/host_service_logs/windows
+
+# Logfile list
+LOGS=(kube-proxy/kube-proxy.log)
+LOGS+=(hybrid-overlay/hybrid-overlay.log)
+LOGS+=(kubelet/kubelet.log)
+LOGS+=(containerd/containerd.log)
+LOGS+=(wicd/windows-instance-config-daemon.exe.INFO wicd/windows-instance-config-daemon.exe.ERROR wicd/windows-instance-config-daemon.exe.WARNING)
+LOGS+=(csi-proxy/csi-proxy.log)
+
+# if the cluster has no Windows nodes skip this script
+WIN_NODES=$(/usr/bin/oc get no -l kubernetes.io/os=windows)
+if [ -z "$WIN_NODES" ]; then
+    exit 0
+fi
+
+PIDS=()
+echo INFO: Collecting logs for all Windows nodes
+for log in ${LOGS[@]}; do
+    LOG_FILE_DIR=${WINDOWS_NODE_LOGS}/log_files/$(dirname $log)
+    mkdir -p ${LOG_FILE_DIR}
+    /usr/bin/oc adm node-logs ${node_log_collection_args:+"$node_log_collection_args"} -l kubernetes.io/os=windows --path=$log > ${LOG_FILE_DIR}/$(basename $log) &
+    PIDS+=($!)
+done
+wait ${PIDS[@]}
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/openshift-must-gather
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/openshift-must-gather
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "WARNING: openshift-must-gather has been DEPRECATED. Use \`oc adm inspect\` instead."
+exec oc adm inspect "$@"
+
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync

--- a/vendor/github.com/openshift/must-gather/collection-scripts/version
+++ b/vendor/github.com/openshift/must-gather/collection-scripts/version
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function version() {
+  if [[ ! -z $OS_GIT_VERSION ]] ; then
+    echo "${OS_GIT_VERSION}"
+  else
+    echo "0.0.0-unknown"
+  fi
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -315,6 +315,9 @@ github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability
+# github.com/openshift/must-gather v0.0.0-20240606205211-408ab8661885 => ../must-gather
+## explicit; go 1.22
+github.com/openshift/must-gather/collection-scripts
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
@@ -1285,3 +1288,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# github.com/openshift/must-gather => ../must-gather


### PR DESCRIPTION
Related jira ticket https://issues.redhat.com/browse/OCPBUGS-34323

[Secrets-store-csi-driver-operator](https://github.com/openshift/secrets-store-csi-driver-operator/tree/main/must-gather) must-gather plugins now has a copy of [common.sh from must-gather repo](https://github.com/openshift/must-gather/blob/master/collection-scripts/common.sh). If there is a bugfix in that script, we must copy it manually. 

We decided the most optimal way for us to have the script up to date is using go vendoring and making the collection-scripts as a go package. This means we need to add go file, marking it as a package. 

We are already using this trick in [Build Machinery Go](https://github.com/openshift/cluster-storage-operator/tree/master/vendor/github.com/openshift/build-machinery-go) where we add it to go.mod and import it in dir [Dependency magnet](https://github.com/openshift/cluster-storage-operator/blob/master/pkg/dependencymagnet/dependencymagnet.go) and the scripts (in this example makefiles) are downloaded.