### PR TITLE
STOR-2126: Enable readOnlyFileSystem

### DIFF
--- a/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
@@ -359,15 +359,23 @@ spec:
                       cpu: 10m
                   terminationMessagePolicy: FallbackToLogsOnError
                   securityContext:
+                    readOnlyRootFilesystem: true
                     allowPrivilegeEscalation: false
                     capabilities:
                       drop:
                       - ALL
+                  volumeMounts:
+                  - mountPath: /tmp
+                    name: tmp
                 priorityClassName: system-cluster-critical
                 securityContext:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                volumes:
+                - name: tmp
+                  emptyDir:
+                    medium: Memory
                 # Strongly prefer a master node, but don't require it.
                 # We want the same Deployment to work on hypershift,
                 # without any master nodes.


### PR DESCRIPTION
Enable readOnlyFileSystem in the operator for security concerns.
Recommended for all containers running in kubernetes.