### PR TITLE
SSCSI-91: Sets readOnlyRootFilesystem to true for all SSCSI driver containers

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -30,6 +30,7 @@ spec:
         - name: csi-driver
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
@@ -84,6 +85,7 @@ spec:
         - name: csi-node-driver-registrar
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           image: ${NODE_DRIVER_REGISTRAR_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
@@ -118,6 +120,8 @@ spec:
             failureThreshold: 5
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-liveness-probe
+          securityContext:
+            readOnlyRootFilesystem: true
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent
           args:


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/SSCSI-91

**Motivation:**
RH ProdSec recommends to have this setting to have uniformilty in following common hardening recommendations.

**Description of changes:**
Sets readOnlyRootFilesystem to true in securityContext of all SSCSI driver containers.
