### PR TITLE
SSCSI-98: Add required go build flags for FIPS

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -2,6 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS 
 WORKDIR /go/src/github.com/openshift/secrets-store-csi-driver-operator
 COPY . .
 RUN make
+RUN go version -m secrets-store-csi-driver-operator
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/secrets-store-csi-driver-operator/secrets-store-csi-driver-operator /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/images.mk \
 )
 
+GO :=CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go
+GO_BUILD_FLAGS :=-trimpath -tags strictfipsruntime,openssl
+
 # Run core verification and all self contained tests.
 #
 # Example:


### PR DESCRIPTION
## Description:
- Enable FIPS-compliant builds via `GOEXPERIMENT=strictfipsruntime`, `CGO_ENABLED=1`, and appropriate build tags.
     - `-tags "strictfipsruntime,openssl"`
- Update Dockerfile to print Go module build info using `go version -m`.

The change will modify the `make build` target from 
```
go build -trimpath -ldflags ...
```
to
```
CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -trimpath -tags strictfipsruntime,openssl -ldflags ...
```

## CI Changes

- https://github.com/openshift/release/pull/64430

Note: Currently, we're relying on the ART golang builder to intercept the non-compliant flags forcefully. This PR is intended to make the binary FIPS compliant by default. 