### PR TITLE
Support Azure workload identity tokens

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -12,3 +12,5 @@ spec:
   fsGroupPolicy: File
   volumeLifecycleModes:
   - Ephemeral
+  tokenRequests:
+  - audience: api://AzureADTokenExchange


### PR DESCRIPTION
Using the [Azure Key Vault provider with workload identities](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/workload-identity-mode/), results in a missing service account token error.

I found and tested the fix from this post, which resolves the issue:

https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/1022#issuecomment-1314260588

Tested on ARO 4.16.39 with managed identities enabled
OLM Operator version 4.16.0-202508201333
Azure provider version 1.7.1