### PR TITLE
SSCSI-235: Add OpenShift Console QuickStart guides for Secrets Store CSI Driver

### DIFF
--- a/demo/console/README.md
+++ b/demo/console/README.md
@@ -1,0 +1,11 @@
+# QuickStarts
+
+This directory includes all the sample manifests for OpenShift Console
+Quick Starts.
+
+Any `QuickStart` or `ConsoleYAMLSample` can be installed via the
+following command:
+
+```
+oc apply -f /path/to/quickstart.yaml
+```

--- a/demo/console/quick-start/secrets-store-csi/sscsi-example-quickstart.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-example-quickstart.yaml
@@ -1,0 +1,138 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: secrets-store-csi-example
+spec:
+  displayName: Secrets Store CSI Driver Operator Example
+  tags:
+    - example
+    - operator
+  durationMinutes: 10
+  prerequisites:
+    - You completed the "Install the Secrets Store CSI Driver Operator" quick start.
+    - You have access to a running secret management system (ex. HashiCorp Vault, Azure Key Vault, etc.)
+    - You know the authentication method configured for your selected secret management system
+    - You have a set of test secrets that you can use for the example.
+    - You have a namespace in which to deploy the example CRs and workloads.
+  description: |-
+    Deploy a simple example application and consume secrets via the Secrets Store CSI Driver operator
+  introduction: |-
+    # Secrets Store CSI Driver Operator
+
+    The secrets store csi driver operator enables you to bring secrets or other "confidential material" into an OpenShift cluster
+    from an external source such as CyberArk Conjur, HashiCorp Vault, or any of the cloud service provider secrets managers.
+
+    ### Expected Learning
+
+    With this Quick Start, you will learn about the following CRD provided by the Secrets Store CSI Driver operator:
+    1. SecretProviderClass
+
+    This Quick Start will walk you through the process of creating a SecretProviderClass and pointing it to a
+    running secrets management system and deploying a Pod that can consume the secret obtained via the
+    SecretProviderClass.
+  tasks:
+    - title: Navigate to installed Secrets Store CSI Driver operator
+      description: |-
+        ### To navigate to the installed operator:
+        1. From the **Administrators** perspective, go to the **Installed Operators** from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
+        2. In the **Search by name** field, type `Secrets Store CSI`.
+        3. Look for **Secrets Store CSI Driver Operator**. If you had completed the prerequisite Quick Start, the tile should appear.
+        4. Click on the installed operator
+
+        You will be brought to the **Operator Details** page and be presented with **Provided APIs**
+      review:
+        instructions: |-
+          #### Verify you see a list of **Provided APIs**:
+          The list should include `SecretProviderClass`
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You are in the right place, and ready to start the rest of the Quick Start
+        failed: Try the steps again.
+    - title: Select a project
+      description: |-
+        ### Create or select a project to work in
+        1. Find the **Project** dropdown menu at the top of the screen.
+        2. Select or create the project in which you want to work in.
+      review:
+        instructions: |-
+          #### Verify the name in the **Project** dropdown menu is the expected project
+        failedTaskHelp: Try the task again.
+      summary:
+        success: You are in the right place.
+        failed: Try the steps again.
+    - title: Create a SecretProviderClass
+      description: |-
+        ### To create a SecretProviderClass
+        1. Find the `SecretProviderClass` Custom Resource in the list of **Provided APIs** or in the top side-scrolling menu bar
+          - From the list of **Provided APIs** click the **Create instance** link
+          - From the **top side-scrolling menu bar** click **SecretProviderClass** and then click **Create SecretProviderClass**
+        2. Fill in the required fields for a `SecretProviderClass` via the form **OR** click the **YAML View** to edit the manifest directly.
+          - NOTE: this includes knowing several pieces of information to properly fill in the `spec.provider` and `spec.secretObjects` fields.
+          This will also include, knowing the authentication method for the `provider` and prosessing any necessary credentials,
+          certificates, tokens, etc. necessary to authenticate against the secret management system chosen.
+          - In **YAML View** you can check the provided **Samples** on the right hand sidebar for some sample configurations.
+        3. When you have filled out the necessary fields or yaml, click the **Create** button to proceed.
+      review:
+        instructions: |-
+          #### Verify the SecretProviderClass was successfully deployed:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You just deployed your first SecretProviderClass. Take note of the name and namespace the SecretProviderClass was deployed with.
+        failed: Try the steps again.
+    - title: Deploy a sample application
+      description: |-
+        ### To deploy a sample application that consumes the managed Secret
+        1. Proceed to the [Workloads]{{highlight qs-nav-workloads}} section and click **Pods**
+        2. Click the **Create Pod** button
+        3. Fill in the yaml with the following `spec`:
+
+        ```yaml
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          name: APPLICATION_NAME
+          namespace: NAMESPACE
+        spec:
+          serviceAccountName: SERVICE_ACCOUNT_NAME
+          securityContext:
+            fsGroup: 2000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - image: busybox:stable
+            name: sscsi-demo
+            command: ["sh", "-c", "while true; do sleep 3600; done"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              runAsNonRoot: true
+            volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/mnt/secrets-store"
+              readOnly: true
+          volumes:
+            - name: secrets-store-inline
+              csi:
+                driver: secrets-store.csi.k8s.io
+                readOnly: true
+                volumeAttributes:
+                  secretProviderClass: SECRETPROVIDERCLASS_NAME
+        ```
+        4. Click the **Create** Button at the bottom of the screen
+      review:
+        instructions: |-
+          #### Verify the Pod was successfully deployed:
+          1. You should see the pod deploy successfully
+          2. Once the pod is successfully Running, click on the running pod
+          3. Proceed to the **terminal** section
+          4. Run the command `ls /mnt/secrets-store/`. You should see a file with your secret.
+          5. You can use the command `cat /mnt/secrets-store/<insert-filename>` to verify the stored secret is correct.
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You just deployed your first application that uses the Secrets Store CSI Driver. The application successfully mounted secrets from your external secret management system.
+        failed: Try the steps again.
+  conclusion: "You have successfully deployed your first application that uses secrets from the Secrets Store CSI Driver operator!"

--- a/demo/console/quick-start/secrets-store-csi/sscsi-install-quickstart.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-install-quickstart.yaml
@@ -1,0 +1,75 @@
+﻿apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: secrets-store-csi-install
+spec:
+  displayName: Install the Secrets Store CSI Driver Operator
+  tags:
+    - example
+    - install
+    - operator
+  durationMinutes: 5
+  description: |-
+    Install the secrets store csi driver operator to manage credentials sourced from an external secrets manager (Conjur, Vault)
+  introduction: |-
+    # Secrets Store CSI Driver Operator
+
+    The secrets store csi driver operator enables you to bring secrets or other "confidential material" into an OpenShift cluster
+    from an external source such as HashiCorp Vault, Azure Key Vault, or any of the cloud service provider secrets managers.
+
+    ## Usage
+
+    You can use a `SecretProviderClass` to define how to connect to the secrets manager and which credentials to pull.
+    These credentials will be mounted to an ephemeral volume on a running workload.
+  tasks:
+    - title: Install the Secrets Store CSI Driver Operator
+      description: |-
+        ### To install the operator:
+        1. From the **Administrators** perspective, go to the **OperatorHub** from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
+        2. In the **Filter by keyword** field, type `Secrets Store CSI`.
+        3. Look for **Secrets Store CSI Driver Operator**. If the tile has an **Installed** label on it, the Operator is already installed, and you can close this Quick Start.
+        4. Click the tile to open the side panel.
+        5. At the top of the side panel, click **Install**.
+        6. Verify that the **Operator Update Channel** is set to the latest version, then click **Install**. You may need to "Approve" the installation.
+        7. Wait for the Secrets Store CSI Driver Operator's status to change from **Installing operator** to **Operator installed successfully - Ready for use**.
+      review:
+        instructions: |-
+          #### Verify the operator was successfully installed:
+          - You should see a success message stating the operator was successfully installed.
+          - Navigate to the [Operators]{{highlight qs-nav-operators}} section and click on **Installed Operators**. You should see the Secrets Store CSI operator installed.
+          - Navigate to [Workloads]{{highlight qs-nav-workloads}} section and click **Pods**.
+          - Select in the top **Project** dropdown menu, the project **openshift-cluster-csi-drivers**
+          - Verify that there is a running Pod: **secrets-store-csi-driver-operator**
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You just installed the Secrets Store CSI Driver Operator!
+        failed: Try the steps again.
+    - title: Deploy the ClusterCSIDriver
+      description: |-
+        ### To deploy the ClusterCSIDriver
+        1. Go to the [Administration]{{highlight qs-nav-administration}} section and click on **CustomResourceDefinitions**
+        2. In the **Search by name** field, type `ClusterCSIDriver` and click on the Custom Resource
+        3. Next to the **Details** tab, select the **Instances** tab.
+        4. Click **Create ClusterCSIDriver**
+        5. Copy the following manifest into the YAML editor field:
+
+        ```yaml
+        apiVersion: operator.openshift.io/v1
+        kind: ClusterCSIDriver
+        metadata:
+            name: secrets-store.csi.k8s.io
+        spec:
+          managementState: Managed
+        ```
+        6. Click the **Create** button
+      review:
+        instructions: |-
+          #### Verify the ClusterCSIDriver is successfully deployed:
+          - Navigate to [Workloads]{{highlight qs-nav-workloads}} section and click **Pods**.
+          - Select in the top **Project** dropdown menu, the project **openshift-cluster-csi-drivers**
+          - Verify that there are running Pods with names starting with: **secrets-store-csi-driver** and **secrets-store-csi-driver-node**
+        failedTaskHelp: Try the task again.
+      summary:
+        success: You've successfully installed all the necessary components for the Secrets Store CSI Driver Operator. Check out the next Quick Start for a simple example of how to use the Custom Resources provided by the operator.
+        failed: Try the steps again.
+  conclusion: "Your secrets store csi driver operator is ready!"

--- a/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-aws.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-aws.yaml
@@ -1,0 +1,26 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: secrets-store-csi-secretproviderclass-aws
+spec:
+  targetResource:
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+  title: Example SecretProviderClass - AWS Secrets Manager
+  description: |
+    An example SecretProviderClass for AWS Secrets Manager
+  yaml: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: NAME
+      namespace: NAMESPACE
+    spec:
+      provider: aws
+      parameters:
+        region: AWS_REGION
+        objects: |
+          - objectName: "SECRET_NAME"
+            objectType: "secretsmanager"
+          - objectName: "PARAMETER_NAME"
+            objectType: "ssmparameter"

--- a/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-azure.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-azure.yaml
@@ -1,0 +1,29 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: secrets-store-csi-secretproviderclass-azure
+spec:
+  targetResource:
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+  title: Example SecretProviderClass - Azure Key Vault
+  description: |
+    An example SecretProviderClass for Azure Key Vault
+  yaml: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: NAME
+      namespace: NAMESPACE
+    spec:
+      provider: azure
+      parameters:
+        clientID: "CLIENT_ID"
+        keyvaultName: "KEY_VAULT_NAME"
+        tenantId: "TENANT_ID"
+        objects: |
+          array:
+            - |
+              objectName: SECRET_NAME
+              objectType: secret
+              objectVersion: ""

--- a/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-gcp.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-gcp.yaml
@@ -1,0 +1,23 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: secrets-store-csi-secretproviderclass-gcp
+spec:
+  targetResource:
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+  title: Example SecretProviderClass - GCP Secret Manager
+  description: |
+    An example SecretProviderClass for GCP Secret Manager
+  yaml: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: NAME
+      namespace: NAMESPACE
+    spec:
+      provider: gcp
+      parameters:
+        secrets: |
+          - resourceName: "projects/PROJECT_ID/secrets/SECRET_NAME/versions/VERSION"
+            fileName: "SECRET_FILE_NAME"

--- a/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-vault.yaml
+++ b/demo/console/quick-start/secrets-store-csi/sscsi-sample-secretproviderclass-vault.yaml
@@ -1,0 +1,26 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: secrets-store-csi-secretproviderclass-sample
+spec:
+  targetResource:
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+  title: Example SecretProviderClass - HashiCorp Vault
+  description: |
+    An example SecretProviderClass for HashiCorp Vault
+  yaml: |
+    apiVersion: secrets-store.csi.x-k8s.io/v1
+    kind: SecretProviderClass
+    metadata:
+      name: NAME
+      namespace: NAMESPACE
+    spec:
+      provider: vault
+      parameters:
+        vaultAddress: "http://VAULT_IP_ADDRESS:8200"
+        roleName: VAULT_ROLE
+        objects: |
+          - objectName: NAME_FOR_MOUNTED_FILE_CONTAINING_SECRET
+            secretPath: SECRET_PATH_IN_VAULT
+            secretKey: SECRET_KEY_NAME_IN_VAULT


### PR DESCRIPTION
## Description

This PR adds OpenShift Console QuickStart guides to provide an interactive, step-by-step experience for getting started with the Secrets Store CSI Driver Operator.

## What's Added

1. **Installation QuickStart** (`sscsi-install-quickstart.yaml`)
2. **Example Usage QuickStart** (`sscsi-example-quickstart.yaml`)
3. **Sample YAML** (`sscsi-sample-secretproviderclass-vault.yaml`)

## Usage

`oc apply -f demo/console/quick-start/secrets-store-csi/`

Access from OpenShift Console under "Quick Starts" menu.

<img width="672" height="589" alt="image" src="https://github.com/user-attachments/assets/c02882f4-4fc0-4618-b8ff-00cf17930a22" />
<img width="399" height="373" alt="image" src="https://github.com/user-attachments/assets/81617142-1483-41fa-9286-de886a51e145" />



/cc @mytreya-rh 