### PR TITLE
SSCSI-271: Enable support for IBM Z platform (s390x arch)

### DIFF
--- a/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
@@ -29,6 +29,7 @@ metadata:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
     "operatorframework.io/arch.arm64": supported
+    "operatorframework.io/arch.s390x": supported
 spec:
   displayName: Secrets Store CSI Driver Operator
   description: >


### PR DESCRIPTION
The software catalog does not show the Secret store CSI Operator for s390x platforms. 
Enable this for 4.22 OCP release for support of SSCSI-operator on s390x. 


The changes have been tested on a s390x cluster and the results have been attached to the jira ticket
https://redhat.atlassian.net/browse/SSCSI-271