### PR TITLE
OAPE-758: Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,231 @@
+# AGENTS.md
+
+## Project Overview
+
+This is the **OpenShift Secrets Store CSI Driver Operator** -- a Go-based Kubernetes operator that manages the lifecycle of the [Secrets Store CSI Driver](https://github.com/openshift/secrets-store-csi-driver) on OpenShift clusters. It is built on the `library-go` controller framework and deployed via OLM (Operator Lifecycle Manager).
+
+The operator watches a `ClusterCSIDriver` custom resource (`secrets-store.csi.k8s.io`) and reconciles a DaemonSet that runs the CSI driver on every Linux node, along with associated RBAC, ServiceAccounts, ConfigMaps, NetworkPolicies, and the CSIDriver object.
+
+## Detailed Guidelines
+
+The following documents cover domain-specific conventions in depth. Read these before working in their respective areas:
+
+- **[docs/security-guidelines.md](docs/security-guidelines.md)** -- RBAC principles, SCC usage, container security contexts, TLS/cert management, host path security, and image reference patterns.
+- **[docs/performance-guidelines.md](docs/performance-guidelines.md)** -- Informer scoping, resource requests/limits, metrics, liveness probes, leader election, static resource management, and DaemonSet update strategy.
+- **[docs/error-handling-guidelines.md](docs/error-handling-guidelines.md)** -- Error wrapping, klog usage, operator status conditions, Sync return patterns, fatal error policy, and test error handling.
+- **[docs/testing-guidelines.md](docs/testing-guidelines.md)** -- Table-driven test patterns, test organization, library-go fakes, assertion style, Makefile targets, E2E testing via `hack/e2e.sh`, and CI integration.
+
+## Repository Layout
+
+```
+cmd/secrets-store-csi-driver-operator/main.go  -- Entry point; wires cobra command + library-go controller
+pkg/operator/starter.go                        -- RunOperator: creates clients, informers, CSI controller set
+pkg/operator/starter_test.go                   -- Unit tests for operator sync state logic
+pkg/version/version.go                         -- Build version info via ldflags; registers Prometheus gauge
+pkg/dependencymagnet/dependencymagnet.go       -- Build-tag-guarded import to keep build-machinery-go vendored
+assets/                                        -- Embedded YAML manifests (go:embed)
+  assets.go                                    -- embed.FS declaration and ReadFile wrapper
+  node.yaml                                    -- DaemonSet for the CSI driver + sidecars
+  node_sa.yaml, csidriver.yaml, cabundle_cm.yaml
+  rbac/                                        -- ClusterRoles and ClusterRoleBindings
+  network-policy/                              -- NetworkPolicy for metrics ingress
+config/manifests/                              -- OLM bundle manifests (CSV, CRDs, package.yaml)
+  art.yaml                                     -- ART version update rules
+  stable/                                      -- Channel-specific manifests
+    image-references                           -- ImageStream for release payload injection
+hack/
+  e2e.sh                                       -- E2E test script (requires running cluster)
+  update-metadata.sh                           -- Bump OCP version across CSV, Makefile, README
+  create-bundle                                -- Build OLM bundle + index images
+must-gather/gather                             -- must-gather collection script
+Dockerfile.openshift                           -- Multi-stage build for the operator image
+Dockerfile.mustgather                          -- must-gather image build
+```
+
+## Architecture
+
+### Controller Framework
+
+The operator uses `library-go`'s `csicontrollerset` to compose multiple sub-controllers into a single controller set. All controllers are configured in `pkg/operator/starter.go:RunOperator`. The controller set includes:
+
+1. **LogLevelController** -- Syncs log level from the `ClusterCSIDriver` spec to the operator.
+2. **ManagementStateController** -- Handles `Managed`/`Unmanaged`/`Removed` lifecycle. This operator is marked **removable** (`true` passed to `WithManagementStateController`).
+3. **ConditionalStaticResourcesController** -- Reconciles static YAML assets (RBAC, ServiceAccount, CSIDriver, ConfigMap, NetworkPolicy) based on management state. Resources are created when `Managed`, deleted when `Removed`.
+4. **CSIConfigObserverController** -- Observes cluster config (infrastructure, proxy, apiserver) and propagates to the operand.
+5. **CSIDriverNodeService** -- Manages the node DaemonSet, including CA bundle injection.
+
+### Operator Client
+
+The operator uses `goc.NewClusterScopedOperatorClientWithConfigName` to create a generic operator client for `ClusterCSIDriver`. Two extractor functions (`extractOperatorSpec`, `extractOperatorStatus`) convert between unstructured objects and typed apply configurations.
+
+### Management State Logic
+
+The `getOperatorSyncState` function determines whether to sync, skip, or delete resources:
+- `Managed` -- normal reconciliation.
+- `Unmanaged` -- skip sync (also the fallback on errors).
+- `Removed` -- delete conditional resources. A `DeletionTimestamp` on the CR is treated as `Removed`.
+
+## Build and Development
+
+### Prerequisites
+
+- Go 1.25+ (matching `go.mod`).
+- `make` (GNU Make).
+- Access to an OpenShift cluster for E2E tests.
+- `oc` CLI for E2E and must-gather testing.
+
+### Key Make Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make` / `make build` | Build the operator binary |
+| `make test-unit` | Run unit tests (`./pkg/... ./cmd/...`) |
+| `make verify` | Run `go vet`, `gofmt` check, Go version consistency |
+| `make test-e2e` | Run E2E tests via `hack/e2e.sh` (requires cluster) |
+| `make check` | Run `verify` then `test-unit` |
+| `make update-gofmt` | Auto-fix formatting |
+| `make clean` | Remove binary and yq tool |
+
+### FIPS Build
+
+The Makefile auto-detects `GOEXPERIMENT=strictfipsruntime` support. In CI, builds use `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` with `-tags strictfipsruntime,openssl`. Local builds without FIPS-capable Go will emit a warning and build without FIPS -- such builds are not valid for CI or production.
+
+### Validation Before Submitting
+
+Always run before pushing:
+```
+make verify && make test-unit
+```
+
+## Dependency Management
+
+### Vendoring
+
+Dependencies are committed in `vendor/`. This is the standard pattern for OpenShift operators.
+
+- Run `go mod tidy && go mod vendor` to update dependencies.
+- The `verify-deps` target (from `build-machinery-go`) validates that `vendor/` matches `go.mod`.
+
+### Key Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| `github.com/openshift/library-go` | Controller framework, CSI controller set, resource apply, operator client |
+| `github.com/openshift/api` | OpenShift API types (`ClusterCSIDriver`, `operator/v1`) |
+| `github.com/openshift/client-go` | OpenShift typed clients and informer factories |
+| `github.com/openshift/build-machinery-go` | Shared Makefile targets for building, testing, vendoring |
+| `k8s.io/client-go` | Kubernetes client, informers, REST config |
+| `k8s.io/apimachinery` | Kubernetes API machinery (unstructured, runtime) |
+| `github.com/spf13/cobra` | CLI command structure |
+| `k8s.io/klog/v2` | Logging |
+
+### Dependency Magnet
+
+`pkg/dependencymagnet/dependencymagnet.go` imports `build-machinery-go` under a `tools` build tag to keep it in `go.mod` and `vendor/` without pulling it into the compiled binary. Do not remove this file.
+
+## Asset Management
+
+### Embedded Assets Pattern
+
+All Kubernetes manifests deployed by the operator live in the `assets/` directory and are compiled into the binary using Go's `embed` package:
+
+```go
+//go:embed *.yaml rbac/*.yaml network-policy/*.yaml
+var f embed.FS
+```
+
+The `assets.ReadFile(name)` function wraps `f.ReadFile`. When adding new assets:
+- Place YAML files under `assets/` or its subdirectories (`rbac/`, `network-policy/`).
+- If adding a new subdirectory, update the `//go:embed` directive in `assets/assets.go` to include the new glob.
+- Register the new file in the appropriate controller in `pkg/operator/starter.go` (e.g., add it to the `WithConditionalStaticResourcesController` file list).
+
+### Namespace Substitution
+
+Assets use `${NAMESPACE}` as a placeholder for the operator namespace. The `replaceNamespaceFunc` in `starter.go` performs byte-level replacement at load time. Use `${NAMESPACE}` (not hardcoded namespace names) in any new asset that references the operator namespace.
+
+### Image Variable Substitution
+
+Container images in `assets/node.yaml` use variables like `${DRIVER_IMAGE}`, `${NODE_DRIVER_REGISTRAR_IMAGE}`, `${LIVENESS_PROBE_IMAGE}`, and `${LOG_LEVEL}`. These are substituted by the library-go DaemonSet controller at runtime from environment variables set on the operator pod.
+
+## Code Conventions
+
+### Package Structure
+
+- `cmd/` -- One sub-package per binary. Contains only CLI wiring (cobra commands, controller config). No business logic.
+- `pkg/operator/` -- Operator startup and controller composition. This is where `RunOperator` lives.
+- `pkg/version/` -- Build version info. Injected via ldflags.
+- `pkg/dependencymagnet/` -- Build-tag-guarded imports for tool dependencies.
+- `assets/` -- Embedded YAML manifests. The `assets.go` file provides the `ReadFile` API.
+
+### Naming Conventions
+
+- **Package names**: lowercase, single-word where possible (`operator`, `version`, `assets`).
+- **File names**: lowercase with underscores (`starter.go`, `starter_test.go`, `node_sa.yaml`).
+- **Constants**: camelCase, unexported unless needed externally (`operatorName`, `providerName`, `namespaceKey`).
+- **Functions**: exported for cross-package use (`RunOperator`, `ReadFile`), unexported for internal helpers (`replaceNamespaceFunc`, `getOperatorSyncState`, `extractOperatorSpec`).
+- **YAML asset names**: descriptive, matching the Kubernetes resource they define (`csidriver.yaml`, `node.yaml`, `privileged_role.yaml`).
+
+### Code Style
+
+- Standard `gofmt` formatting. No custom linter configuration beyond `go vet`.
+- Imports grouped in standard Go convention: stdlib, external, internal -- separated by blank lines.
+- No assertion libraries. Use standard `if` checks with `t.Fatalf` or `t.Errorf`.
+- No third-party mocking frameworks. Use `library-go` fakes.
+- Error messages start with a lowercase verb: `"unable to convert..."`, `"failed to get..."`.
+
+### Operator Pattern Conventions
+
+- The operator manages a **single binary** that contains all controllers.
+- Controllers are composed via `csicontrollerset` method chaining, not registered individually.
+- The operator is **cluster-scoped** -- it watches a cluster-scoped `ClusterCSIDriver` CR.
+- The operator is **removable** -- it supports the `Removed` management state and cleans up resources on deletion.
+- Static resources (RBAC, SA, ConfigMap, CSIDriver, NetworkPolicy) use `WithConditionalStaticResourcesController`. The DaemonSet uses `WithCSIDriverNodeService`. Do not mix these patterns.
+- Informers are scoped to the operator namespace and cluster scope (`""`) -- not all namespaces.
+
+## OLM and Release
+
+### Version Bumping
+
+When the OCP version changes, run:
+```
+./hack/update-metadata.sh X.Y
+```
+This updates the package manifest, CSV, Makefile image tags, and README registry references.
+
+### OLM Bundle
+
+The operator is packaged as an OLM bundle. Key files:
+- `config/manifests/secrets-store-csi-driver-operator.package.yaml` -- Package name and channel.
+- `config/manifests/stable/*.clusterserviceversion.yaml` -- CSV with deployment spec, RBAC, and owned CRDs.
+- `config/manifests/stable/image-references` -- Image stream mapping for release payload.
+- `config/metadata/annotations.yaml` -- OLM bundle metadata.
+- `config/manifests/art.yaml` -- ART (Automated Release Tooling) version substitution rules.
+
+### Operator Namespace
+
+The operator runs in `openshift-cluster-csi-drivers` (set via OLM's `suggested-namespace` annotation). All namespace-scoped resources are created in this namespace.
+
+## CI/CD
+
+- CI runs in OpenShift Prow. Configuration lives in `openshift/release`, not this repo.
+- `.ci-operator.yaml` specifies the build root image.
+- Every PR runs: `make verify` and `make test-unit`.
+- E2E tests run as Prow jobs against real clusters.
+- CI builds enforce FIPS compliance via the `strictfipsruntime` build experiment.
+
+## Common Pitfalls
+
+- **Missing embed directive update**: When adding a new subdirectory under `assets/`, you must update the `//go:embed` directive in `assets/assets.go`. A missing glob will cause a `panic` at runtime.
+- **Hardcoded namespaces in assets**: Always use `${NAMESPACE}` in YAML assets for namespace fields. Hardcoding a namespace will break deployments in non-default namespaces.
+- **Wrong controller for new resources**: Static resources go in `WithConditionalStaticResourcesController`. The DaemonSet goes in `WithCSIDriverNodeService`. Mixing these causes incorrect lifecycle management.
+- **Cluster-wide informers**: Do not create informers that watch all namespaces. Use `NewKubeInformersForNamespaces` with explicit namespace lists.
+- **Non-vendored dependencies**: All dependencies must be vendored. A `go.sum`-only dependency will fail CI.
+- **FIPS build failures locally**: If your local Go does not support `GOEXPERIMENT=strictfipsruntime`, the build will succeed with a warning but produce a non-FIPS binary. This is fine for local development.
+- **Panics in reconciliation**: `panic` is only acceptable for build-time bugs (missing embedded assets). Return errors in reconciliation loops and let the framework retry.
+
+## Behavioral Preferences
+
+- Always run `make verify && make test-unit` before suggesting a PR is ready.
+- After modifying Go files, run `make verify` to catch formatting or vet issues early.
+- After modifying files under `assets/`, verify the `//go:embed` directive in `assets/assets.go` covers the new paths.
+- E2E tests (`make test-e2e`) require a live OpenShift cluster and are not expected to pass locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,56 @@
+# Error Handling Guidelines
+
+## Error Wrapping
+
+- Wrap errors with `fmt.Errorf("context: %w", err)` to preserve the error chain. This is the standard pattern used throughout the codebase (see `pkg/operator/starter.go`).
+- Keep context messages short and descriptive: `"unable to convert to ClusterCSIDriver: %w"`, not `"an error occurred while trying to convert the object to a ClusterCSIDriver type: %w"`.
+- Use `%w` (not `%v`) so callers can use `errors.Is` and `errors.As` on the wrapped error.
+
+## Logging
+
+- Use `klog` for all logging — the operator framework and Kubernetes ecosystem standardize on it.
+- Use `klog.Errorf` for errors that indicate operator malfunction: `klog.Errorf("unable to get operator state: %v", err)`.
+- Use `klog.Infof` for normal operational events.
+- Use `klog.Warningf` sparingly — only for situations that are recoverable but unexpected.
+- Format log messages starting with a lowercase verb: `"unable to get..."`, `"syncing..."`, `"skipping..."`.
+- Avoid logging secret values, tokens, or credentials. Log resource names and namespaces, not resource contents.
+- Use `klog.V(n)` for debug-level messages. The operator supports standard klog verbosity flags.
+
+## Operator Status and Conditions
+
+- The operator uses `library-go`'s generic operator client (via `goc.NewClusterScopedOperatorClientWithConfigName`) to manage `ClusterCSIDriver` status.
+- The CSI controller set framework manages standard operator status conditions:
+  - `Available` — the operator and its operand are functioning correctly.
+  - `Progressing` — the operator is actively working toward a desired state.
+  - `Degraded` — the operator encountered an error that prevents normal operation.
+- Set `Degraded=True` when the operator cannot reconcile desired state after retries, not on every transient error.
+
+## Error Return Patterns
+
+- Controller `Sync` methods return `error` — the framework handles requeueing on error.
+- Return `nil` from `Sync` when the reconciliation succeeded, even if some optional work was skipped.
+- Return an error from `Sync` only when the primary reconciliation objective failed — this triggers a requeue.
+- Do not return errors for expected states like "resource not found during initial setup" — handle those inline.
+
+## Fatal Errors at Startup
+
+- Use `klog.Fatal` or `os.Exit(1)` only during operator startup (`cmd/secrets-store-csi-driver-operator/main.go`) when initialization fails irrecoverably.
+- The operator uses `panic(err)` in `replaceNamespaceFunc` (`pkg/operator/starter.go`) when asset loading fails — a missing embedded asset is a build-time bug, not a runtime error.
+- Avoid using `Fatal` or `panic` in reconciliation loops — return an error and let the framework retry.
+
+## Container Termination Messages
+
+- DaemonSet containers set `terminationMessagePolicy: FallbackToLogsOnError` so Kubernetes captures the last log lines as the termination message when a container crashes.
+- Keep this policy on all containers — it aids debugging without requiring log aggregation access.
+
+## Error Handling in Tests
+
+- Use `t.Fatalf` for setup failures that make the rest of the test meaningless.
+- Use `t.Errorf` for assertion failures where subsequent checks may still provide useful information.
+- In table-driven tests, use `t.Run(tc.name, ...)` within each subtest so all cases run even if one fails. Note: the existing test in `pkg/operator/starter_test.go` uses `t.Fatalf` for assertions in subtests.
+
+## Configuration Validation
+
+- Validate operator configuration at startup before entering the reconciliation loop.
+- The `RunOperator` function in `pkg/operator/starter.go` validates required clients and informers before starting controllers.
+- Fail fast with a clear error message if required configuration is missing, rather than entering a degraded reconciliation loop.

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,57 @@
+# Performance Guidelines
+
+## Informer and Controller Patterns
+
+- This operator uses the `library-go` controller framework via `NewKubeInformersForNamespaces`.
+- The config informer factory uses a 20-minute resync period (`resync = 20 * time.Minute` in `pkg/operator/starter.go`). Kube informers via `NewKubeInformersForNamespaces` use a 10-minute resync (library-go default).
+- Scope informers to the specific namespaces needed. The operator watches the operator namespace and cluster-scoped resources via `NewKubeInformersForNamespaces` rather than cluster-wide informers, reducing API server load.
+- When adding new watchers, scope to the minimum required namespace set instead of watching all namespaces.
+
+## Resource Requests and Limits
+
+- DaemonSet containers in `assets/node.yaml` set resource requests but no limits:
+  - `csi-driver` container: `cpu: 10m`, `memory: 50Mi`
+  - `csi-node-driver-registrar`: `cpu: 10m`, `memory: 50Mi`
+  - `csi-liveness-probe`: `cpu: 10m`, `memory: 50Mi`
+- Follow this pattern: set requests for scheduling guarantees, omit limits to allow burst usage.
+- Keep requests conservative — the node plugin runs on every node as a DaemonSet, so per-pod resource requests multiply across the cluster.
+
+## Volume and Mount Configuration
+
+- The DaemonSet uses `hostPath` volumes with explicit `type` (`DirectoryOrCreate` or `Directory`) for CSI plugin directories and provider paths.
+- Mount secrets-store provider paths as `hostPath` with `DirectoryOrCreate` — the paths are `/var/run/secrets-store-csi-providers` and `/etc/kubernetes/secrets-store-csi-providers`.
+
+## Metrics and Monitoring
+
+- The CSI driver exposes Prometheus metrics on port 8095, configured via the `--metrics-addr=:8095` flag in the driver container.
+- Metrics are served behind TLS using auto-provisioned certificates from OpenShift's service-ca.
+- When adding new metrics, register them in the driver startup and ensure they have bounded cardinality — avoid labels with unbounded values (pod names, UIDs).
+
+## Liveness and Readiness Probes
+
+- The `csi-driver` container has a liveness probe that checks the CSI driver's health via HTTP:
+  - `httpGet` on port 9808 (named `healthz`), path `/healthz`
+  - `failureThreshold: 5`, `initialDelaySeconds: 30`, `timeoutSeconds: 10`, `periodSeconds: 15`
+- The `csi-liveness-probe` sidecar provides the health endpoint at port 9808 by connecting to the Unix socket at `/csi/csi.sock`.
+- These values balance responsiveness with tolerance for transient failures — keep the 5-failure threshold to avoid unnecessary restarts during brief node pressure.
+
+## Leader Election
+
+- The operator uses `library-go`'s built-in leader election via `NewControllerCommandConfig` — a single leader runs the control loops.
+- The operator binary accepts standard leader-election flags from the controller framework. Do not implement custom leader election.
+
+## Operator Static Resource Management
+
+- The operator uses `library-go`'s `WithConditionalStaticResourcesController` to reconcile static assets (ServiceAccounts, ClusterRoles, ClusterRoleBindings, ConfigMaps, CSIDriver) from the `assets/` directory.
+- Static resources are re-synced periodically by the controller — avoid expensive operations in asset rendering (template expansion).
+- Assets are loaded via `assets.ReadFile()` using Go's `embed.FS` — they are compiled into the binary at build time and cached.
+
+## Build and Binary Size
+
+- The Makefile uses `GO_BUILD_FLAGS` for build optimization, including `-trimpath` and optional FIPS tags.
+- The operator builds a single binary via `cmd/secrets-store-csi-driver-operator/main.go` — keep the binary footprint small by not pulling unnecessary dependencies.
+
+## DaemonSet Update Strategy
+
+- The node DaemonSet uses `RollingUpdate` strategy with `maxUnavailable: 10%` — this prevents all nodes from restarting simultaneously during updates.
+- Keep `maxUnavailable` at or below 10% for DaemonSets that run on every node.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,58 @@
+# Security Guidelines
+
+## RBAC Principles
+
+- Follow least-privilege: each component gets its own `ClusterRole` scoped to exactly the verbs and resources it needs.
+- The operator defines two ClusterRoles in `assets/rbac/`:
+  - **`privileged_role.yaml`** — grants `use` on the `privileged` SecurityContextConstraint (SCC). Only the node plugin DaemonSet ServiceAccount binds this (via `node_privileged_binding.yaml`).
+  - **`secretproviderclasses_role.yaml`** — node-plugin permissions: `get`/`list`/`watch` on `secrets`, `pods`, `secretproviderclasses`, `csidrivers`; full CRUD on `secrets` (for rotation/syncing) and `secretproviderclasspodstatuses`; `create`/`patch` on `events`; `create` on `serviceaccounts/token` (bound token minting). Bound via `secretproviderclasses_binding.yaml`.
+- Prefer keeping per-component RBAC separation so a compromised component cannot escalate.
+- When adding a new resource permission, add it to the correct component role, not a shared one.
+
+## SecurityContextConstraints (SCC)
+
+- The node plugin DaemonSet runs under the `privileged` SCC because CSI node drivers require host-level access (mount propagation, `/var/lib/kubelet` access).
+- The `privileged_role.yaml` + `node_privileged_binding.yaml` pair grants this — avoid adding `privileged` SCC access to other components without justification.
+- Prefer `readOnlyRootFilesystem: true` on all containers. The node-registrar sidecar already sets this.
+
+## Container Security Contexts
+
+- The `csi-driver` container in the DaemonSet (`assets/node.yaml`) runs with `privileged: true`, required for CSI mount operations.
+- The `csi-node-driver-registrar` sidecar runs with `privileged: true` and `readOnlyRootFilesystem: true`.
+- The `csi-liveness-probe` sidecar runs non-privileged with `readOnlyRootFilesystem: true`.
+- When adding new containers, default to non-privileged with `readOnlyRootFilesystem: true`. Only escalate with a documented justification.
+
+## Service Account Token Handling
+
+- The node plugin uses `serviceaccounts/token` create permission to mint short-lived bound tokens for pod identity.
+- Projected service account tokens should be mounted via `serviceAccountToken` volume projections with explicit `expirationSeconds` and `audience` when applicable.
+
+## TLS and Certificate Management
+
+- The operator creates a `Service` for metrics/healthz endpoints with `service.beta.openshift.io/serving-cert-secret-name` annotation — OpenShift's service-ca-operator auto-generates and rotates the TLS certificate.
+- CA bundles are injected via ConfigMaps annotated with `config.openshift.io/inject-trusted-cabundle: "true"` (see `assets/cabundle_cm.yaml`).
+- Prefer annotation-based auto-provisioning over hard-coding certificates or keys in manifests.
+- The operator mounts the CA bundle and serving cert into the operand as volumes — see `assets/node.yaml` for the volume/volumeMount pattern.
+
+## Image References
+
+- Container images use variable substitution (`${NODE_DRIVER_REGISTRAR_IMAGE}`, `${LIVENESS_PROBE_IMAGE}`, etc.) for deploy-time image injection.
+- Prefer the substitution pattern so the operator can pin images from the cluster's release payload rather than hard-coding image tags or digests.
+
+## Secrets Handling in Code
+
+- The operator reads ClusterCSIDriver and related config objects to determine desired state — it does not directly handle user secrets.
+- The CSI driver itself (upstream, not this operator) handles secret volume mounts. This operator only manages the lifecycle of the driver deployment.
+- Avoid logging secret values. The operator uses `klog` — ensure no secret content reaches log statements.
+
+## Host Path Security
+
+- The DaemonSet mounts several host paths: `/var/lib/kubelet/pods` (for CSI), `/var/lib/kubelet/plugins`, `/run/secrets-store-csi`.
+- Host path mounts should use explicit `type: DirectoryOrCreate` or `type: Directory`.
+- `mountPropagation: Bidirectional` is set on the kubelet pods mount so CSI-mounted volumes are visible to the host. Do not use Bidirectional propagation on other mounts without justification.
+
+## Network and Port Security
+
+- Metrics are served on container port 8095, exposed via a `Service` with TLS (auto-provisioned cert).
+- The CSI driver endpoint listens on a Unix socket at `/csi/csi.sock` — not a TCP port. Prefer Unix sockets for driver endpoints to avoid network exposure.
+- Liveness probes use HTTP on port 9808, served by the `csi-liveness-probe` sidecar container.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,74 @@
+# Testing Guidelines
+
+## Test Structure
+
+- Use table-driven tests with named test cases as the default pattern. Each test case is a struct with a descriptive `name` field.
+- Run subtests with `t.Run(tc.name, func(t *testing.T) { ... })` so each case appears as a separate subtest in output and can be run individually.
+- Name test cases descriptively to explain the scenario being tested, e.g., `"operator state is Removed when ClusterCSIDriver does not exist"`.
+
+## Test Organization
+
+- Place unit tests in `_test.go` files alongside the code they test in the same package.
+- The main test file is `pkg/operator/starter_test.go` — match this pattern for new packages.
+- E2E tests are invoked via `hack/e2e.sh`.
+
+## Fakes and Mocks
+
+- Use `library-go`'s `FakeOperatorClient` (`v1helpers.NewFakeOperatorClientWithObjectMeta`) for unit testing operator logic without a real cluster.
+- Use the `FakeOperatorClient` pattern to set up operator spec, status, and object metadata for testing sync behavior.
+- Do not use third-party mocking frameworks — prefer hand-written fakes and the standard library's testing utilities.
+
+## Test Assertions
+
+- Use standard `if` checks with `t.Errorf` or `t.Fatalf` — no assertion libraries.
+- Use `t.Fatalf` when a failure makes the rest of the test meaningless (e.g., setup failure, nil pointer).
+- Use `t.Errorf` when subsequent assertions may still provide useful diagnostic information.
+- Compare expected values explicitly: `if got != want { t.Fatalf("expected sync state to be %v, got %v", want, got) }`.
+
+## Test Data and Fixtures
+
+- Operator manifests (YAML assets) are embedded in the binary via `//go:embed` in `assets/assets.go` and loaded via `assets.ReadFile()`. Tests that depend on these assets can use the same loading mechanism.
+- Test data for operator state is constructed inline in test cases using struct literals — no external fixture files for unit tests.
+
+## Makefile Test Targets
+
+- `make test-unit` — runs unit tests via `go test`.
+- `make test-e2e` — runs end-to-end tests via `hack/e2e.sh`.
+- `make verify` — runs code verification (formatting, vetting, Go version checks).
+- `make test` — runs `test-unit` (the default test target).
+- Run `make verify` before submitting changes to catch formatting and vet issues.
+
+## E2E Testing
+
+- E2E tests require a running OpenShift cluster and are executed via `hack/e2e.sh`.
+- The e2e script handles test setup, execution, and teardown including artifact collection.
+- The e2e script creates an ephemeral namespace (`secrets-store-test-ns-<random>`) and cleans it up via `test_teardown`.
+- E2E tests validate: CSIDriver resource existence, provider pod readiness, SecretProviderClass creation, and secret volume mounting.
+- E2E tests are run in CI via Prow jobs — they are not expected to run locally in most development workflows.
+
+## Code Verification
+
+- `make verify` checks:
+  - `go vet ./...` for common Go issues.
+  - `gofmt` for code formatting.
+  - Go version consistency across `go.mod` and Dockerfile.
+- Run `make verify` locally before pushing to catch issues that would fail in CI.
+- Verification checks are implemented in vendored `build-machinery-go` makefiles.
+- Fix formatting violations with `make update-gofmt`.
+
+## CI Integration
+
+- Tests run in OpenShift CI (Prow) on every pull request.
+- The CI configuration lives in the `openshift/release` repository, not in this repo.
+- CI runs `make test-unit` and `make verify` on every PR.
+- E2E tests run as periodic or pre-submit Prow jobs against a real cluster.
+- CI builds use FIPS-compliant build flags (`CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` with `-tags strictfipsruntime,openssl`).
+
+## Adding New Tests
+
+1. Place the test file next to the source file it tests, using the same package name.
+2. Use table-driven tests with descriptive `name` fields.
+3. Use `t.Fatalf` for fatal assertions and `t.Errorf` for non-fatal assertions; do not import external assertion libraries.
+4. Use `library-go` fakes (`v1helpers.NewFakeOperatorClientWithObjectMeta`) for operator client mocking.
+5. If the test needs new assets, add the YAML to `assets/` and update the embed directive if a new subdirectory is introduced.
+6. Run `make verify && make test-unit` locally before submitting a PR.


### PR DESCRIPTION
* generated using `/agent-readiness` from https://github.com/gwenneg/claude-engineering-toolkit

xref: https://drive.google.com/file/d/1v_REchp056aWNzMLSjeUvqXVXBJewvop/view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor/operator guidelines in `AGENTS.md` covering build/test/verification workflows, embedded asset and YAML substitution conventions, OLM/versioning guidance, and common pitfalls.
  * Added standardized error-handling guidelines covering logging, reconciliation/error semantics, condition expectations, and safe startup fatal behavior.
  * Added performance guidelines for informer/controller scoping, resource sizing, metrics and probe expectations, and DaemonSet rollout tuning.
  * Added security guidelines for least-privilege RBAC, SCC/container hardening, token/TLS practices, and secret/log safety.
  * Added testing guidelines covering unit/E2E conventions, test structure, mocking approach, embedded fixtures, and common make/CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->