### PR TITLE
STOR-2920: Bump OLM metadata to 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,secrets-store-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.22:secrets-store-csi-driver-operator,./Dockerfile.openshift,.)
+$(call build-image,secrets-store-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/5.0:secrets-store-csi-driver-operator,./Dockerfile.openshift,.)
 
 clean: clean-yq
 	$(RM) secrets-store-csi-driver-operator

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To build bundle and index images, use the `hack/create-bundle` script:
 
 ```shell
 cd hack
-./create-bundle registry.ci.openshift.org/ocp/4.22:secrets-store-csi-driver registry.ci.openshift.org/ocp/4.22:secrets-store-csi-driver-operator quay.io/<my_user>/secrets-store-bundle quay.io/<my_user>/secrets-store-index
+./create-bundle registry.ci.openshift.org/ocp/5.0:secrets-store-csi-driver registry.ci.openshift.org/ocp/5.0:secrets-store-csi-driver-operator quay.io/<my_user>/secrets-store-bundle quay.io/<my_user>/secrets-store-index
 ```
 
 At the end it will print a command that creates `Subscription` for the newly created index image.

--- a/config/manifests/secrets-store-csi-driver-operator.package.yaml
+++ b/config/manifests/secrets-store-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: secrets-store-csi-driver-operator
 channels:
   - name: stable
-    currentCSV: secrets-store-csi-driver-operator.v4.22.0
+    currentCSV: secrets-store-csi-driver-operator.v5.0.0

--- a/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/secrets-store-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: secrets-store-csi-driver-operator.v4.22.0
+  name: secrets-store-csi-driver-operator.v5.0.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,8 +13,8 @@ metadata:
     repository: https://github.com/openshift/secrets-store-csi-driver-operator
     createdAt: "2023-06-12T00:00:00Z"
     description: Install and configure Secrets Store CSI driver.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
-    olm.skipRange: ">=4.13.0-0 <4.22.0"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]'
+    olm.skipRange: ">=4.13.0-0 <5.0.0"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
@@ -45,7 +45,7 @@ spec:
       url: https://github.com/openshift/secrets-store-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/secrets-store-csi-driver-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -55,7 +55,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: secrets-store-csi-driver-operator
-    alm-status-descriptors: secrets-store-csi-driver-operator.v4.22.0
+    alm-status-descriptors: secrets-store-csi-driver-operator.v5.0.0
   selector:
     matchLabels:
       alm-owner-metering: secrets-store-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2920

Changes generated with:

`make metadata VERSION=5.0.0`

/cc @openshift/storage @mytreya-rh @chiragkyal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Operator version updated to 5.0.0
  * Updated OpenShift maximum version support to 5.1
  * Version references updated across manifests and documentation
  * Build configuration updated for OCP 5.0 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->